### PR TITLE
Add contributor Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,23 @@
+# Contributor Code of Conduct
+
+This project follows the [Contributor Covenant](https://www.contributor-covenant.org/) Code of Conduct. We expect everyone participating in this community to show respect and courtesy to others.
+
+## Our Standards
+
+* Demonstrate empathy and kindness toward other people.
+* Respect differing viewpoints and experiences.
+* Provide and gracefully accept constructive feedback.
+* Accept responsibility and apologize to those affected by our mistakes, and learn from the experience.
+* Focus on what is best for the community.
+
+Unacceptable behavior includes harassment, insults, or discriminatory jokes and language.
+
+## Reporting Problems
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project maintainers at <samuel_howells@hotmail.com>. All complaints will be reviewed and investigated promptly and fairly.
+
+## Enforcement
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+By contributing you agree to follow this Code of Conduct.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ See `examples/demo_repair.py` for a simple demonstration. Run the tests with:
 pytest -q
 ```
 
+Please see our [Code of Conduct](CODE_OF_CONDUCT.md) for guidelines on contributing respectfully.
+
 ## LICENCE Options for `Brian`
 
 This project uses a **dual-licence** model to ensure:


### PR DESCRIPTION
## Summary
- add a CODE_OF_CONDUCT describing expected behaviour, reporting and enforcement
- reference the Code of Conduct from the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841294550d48329bfdeb3a8c61da476