### PR TITLE
Fix __init__ block quoting

### DIFF
--- a/github_migration_script.py
+++ b/github_migration_script.py
@@ -181,7 +181,7 @@ try:
     from .core.rev_eng import Rev_Eng
 except ImportError:
     # Graceful degradation during initial setup
-    TSAL_SYMBOLS = {}
+    TSAL_SYMBOLS = {{}}
     Rev_Eng = None
 
 # Mesh axioms


### PR DESCRIPTION
## Summary
- escape empty dict in `__init__` content
- confirm multiline strings close properly

## Testing
- `python -m py_compile github_migration_script.py`

------
https://chatgpt.com/codex/tasks/task_e_68412bb719948329a96873aeb7f2c26f