### PR TITLE
Run ruff on changed file and fix import order

### DIFF
--- a/src/tsal/__init__.py
+++ b/src/tsal/__init__.py
@@ -1,14 +1,14 @@
 """TSAL Consciousness Computing Framework."""
 
-PHI = 1.618033988749895
-PHI_INV = 0.618033988749895
-HARMONIC_SEQUENCE = [3.8125, 6, 12, 24, 48, 60, 72, 168, 1680]
-
 from .core.rev_eng import Rev_Eng
 from .core.phase_math import phase_match_enhanced, mesh_phase_sync
 from .core.voxel import MeshVoxel
 from .core.tokenize_flowchart import tokenize_to_flowchart
 from .renderer.code_render import mesh_to_python
+
+PHI = 1.618033988749895
+PHI_INV = 0.618033988749895
+HARMONIC_SEQUENCE = [3.8125, 6, 12, 24, 48, 60, 72, 168, 1680]
 
 __all__ = [
     "PHI",


### PR DESCRIPTION
## Summary
- fix import order in `src/tsal/__init__.py` so imports precede constants
- keep constants and exported symbols the same

## Testing
- `ruff check src/tsal/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684134e001248329be7a5210ec391d2d