### PR TITLE
Add module docstring for code renderer

### DIFF
--- a/src/tsal/renderer/code_render.py
+++ b/src/tsal/renderer/code_render.py
@@ -1,3 +1,5 @@
+"""Provide utilities for regenerating Python code from flowchart nodes."""
+
 from typing import List, Dict
 
 


### PR DESCRIPTION
## Summary
- add module-level docstring explaining purpose of `code_render.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841991b41e083299ddaa345a04174a1