### PR TITLE
Update schema path in demo

### DIFF
--- a/examples/mesh_pipeline_demo.py
+++ b/examples/mesh_pipeline_demo.py
@@ -1,10 +1,12 @@
 from tsal.core.tokenize_flowchart import tokenize_to_flowchart
 from tsal.renderer.code_render import mesh_to_python
 from tsal.core.phase_math import phase_match_enhanced
+from importlib import resources
 
 with open("examples/broken_code.py") as f:
     lines = f.readlines()
 
-nodes, edges = tokenize_to_flowchart(lines, "schemas/python.json")
+schema_path = resources.files("tsal.schemas").joinpath("python.json")
+nodes, edges = tokenize_to_flowchart(lines, schema_path)
 python_code = mesh_to_python(nodes)
 print(python_code)


### PR DESCRIPTION
## Summary
- use importlib.resources to locate bundled schema in `mesh_pipeline_demo.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684199d6a1708329b1062702aaa15581