### PR TITLE
Add GitHub language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ pip install -e .
 ```bash
 pytest -q
 ```
+
+## GitHub Language Database
+
+You can fetch the list of programming languages used on GitHub with:
+
+```python
+from tsal.utils.github_api import fetch_languages
+langs = fetch_languages()
+print(len(langs))
+```
+
+This data can be supplied to Brian's optimizer when analyzing or repairing code.
 ## Quickstart
 1. Put your input code in `examples/broken_code.py`
 2. Run `python examples/mesh_pipeline_demo.py`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [ { name = "Samuel Edward Howells", email = "Samuel_Howells@hotmail.co
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
-dependencies = ["requests"]
+dependencies = ["requests", "pyyaml"]
 
 [project.optional-dependencies]
 test = ["pytest"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 requests
+pyyaml

--- a/src/tsal/__init__.py
+++ b/src/tsal/__init__.py
@@ -6,7 +6,7 @@ from .core.voxel import MeshVoxel
 from .core.tokenize_flowchart import tokenize_to_flowchart
 from .core.json_dsl import LanguageMap, SymbolicProcessor
 from .renderer.code_render import mesh_to_python
-from .utils.github_api import fetch_repo_files
+from .utils.github_api import fetch_repo_files, fetch_languages
 
 PHI = 1.618033988749895
 PHI_INV = 0.618033988749895
@@ -24,5 +24,6 @@ __all__ = [
     "LanguageMap",
     "SymbolicProcessor",
     "fetch_repo_files",
+    "fetch_languages",
     "mesh_to_python",
 ]

--- a/src/tsal/utils/__init__.py
+++ b/src/tsal/utils/__init__.py
@@ -1,6 +1,6 @@
 """Utility modules for TSAL."""
 
 from .error_dignity import activate_error_dignity
-from .github_api import fetch_repo_files
+from .github_api import fetch_repo_files, fetch_languages
 
-__all__ = ["activate_error_dignity", "fetch_repo_files"]
+__all__ = ["activate_error_dignity", "fetch_repo_files", "fetch_languages"]

--- a/src/tsal/utils/github_api.py
+++ b/src/tsal/utils/github_api.py
@@ -1,5 +1,6 @@
 import requests
 from typing import Dict, List, Optional
+import yaml
 
 
 def _get_json(url: str, headers: Dict[str, str]) -> List[Dict]:
@@ -30,5 +31,13 @@ def fetch_repo_files(repo: str, extensions: Optional[List[str]] = None, token: O
         return files
 
     return recurse("")
+
+
+def fetch_languages(url: str = "https://raw.githubusercontent.com/github/linguist/master/lib/linguist/languages.yml") -> List[str]:
+    """Return the list of programming languages from GitHub's Linguist database."""
+    resp = requests.get(url)
+    resp.raise_for_status()
+    data = yaml.safe_load(resp.text)
+    return list(data.keys())
 
 

--- a/tests/unit/test_utils/test_github_api.py
+++ b/tests/unit/test_utils/test_github_api.py
@@ -1,7 +1,12 @@
-from tsal.utils.github_api import fetch_repo_files
+from tsal.utils.github_api import fetch_repo_files, fetch_languages
 
 
 def test_fetch_repo_files_public():
     files = fetch_repo_files("octocat/Hello-World")
     assert any(name.endswith("README") for name in files)
+
+
+def test_fetch_languages_live():
+    languages = fetch_languages()
+    assert "Python" in languages
 


### PR DESCRIPTION
## Summary
- add `fetch_languages` helper to pull the Linguist languages database
- document how to retrieve languages
- export `fetch_languages` in the package init
- add tests
- require PyYAML dependency

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841a365284c8329931b894cf12274f6