### PR TITLE
Add GitHub language ingestion utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ langs = fetch_languages()
 print(len(langs))
 ```
 
+To save these languages for reuse, populate the local SQLite database with:
+
+```bash
+python -m tsal.utils.language_db
+```
+
+This creates `system_io.db` containing a `languages` table with all entries.
+
 This data can be supplied to Brian's optimizer when analyzing or repairing code.
 ## Quickstart
 1. Put your input code in `examples/broken_code.py`

--- a/src/tsal/utils/language_db.py
+++ b/src/tsal/utils/language_db.py
@@ -1,0 +1,49 @@
+import sqlite3
+from typing import Sequence, Optional
+
+from .github_api import fetch_languages
+
+
+def populate_language_db(db_path: str = "system_io.db", languages: Optional[Sequence[str]] = None) -> int:
+    """Populate a SQLite DB with GitHub languages.
+
+    Parameters
+    ----------
+    db_path: str
+        Path to the SQLite database file.
+    languages: Sequence[str] | None
+        Languages to store. If None, fetch from GitHub.
+
+    Returns
+    -------
+    int
+        Total number of languages stored in the database.
+    """
+    if languages is None:
+        languages = fetch_languages()
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS languages (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT UNIQUE)"
+    )
+    cur.executemany("INSERT OR IGNORE INTO languages (name) VALUES (?)", [(lang,) for lang in languages])
+    conn.commit()
+    count = cur.execute("SELECT COUNT(*) FROM languages").fetchone()[0]
+    conn.close()
+    return count
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Populate local language database from GitHub linguist")
+    parser.add_argument("--db", default="system_io.db", help="Path to SQLite database")
+    args = parser.parse_args(argv)
+
+    count = populate_language_db(args.db)
+    print(f"{count} languages stored in {args.db}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_utils/test_language_db.py
+++ b/tests/unit/test_utils/test_language_db.py
@@ -1,0 +1,18 @@
+from tsal.utils.language_db import populate_language_db
+import sqlite3
+
+
+def test_populate_language_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "tsal.utils.language_db.fetch_languages", lambda: ["Python", "Rust"]
+    )
+    db = tmp_path / "lang.db"
+    count = populate_language_db(db_path=str(db))
+    assert count == 2
+
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("SELECT name FROM languages")
+    rows = {row[0] for row in cur.fetchall()}
+    conn.close()
+    assert rows == {"Python", "Rust"}


### PR DESCRIPTION
## Summary
- add `language_db` utility for storing GitHub Linguist languages in SQLite
- document how to ingest languages
- test the new database helper

## Testing
- `pytest -q`
- `python -m tsal.utils.language_db --db /tmp/lang.db`

------
https://chatgpt.com/codex/tasks/task_e_6841ac7a1dec8329aa99b41f2cfbb0b3