### PR TITLE
Add EthicsEngine core module

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,24 @@ This data can be supplied to Brian's optimizer when analyzing or repairing code.
 2. Run `python examples/mesh_pipeline_demo.py`
 3. The pipeline prints regenerated Python code
 
+## Guardian Prime Directive
+
+The `EthicsEngine` enforces the project's core principles:
+
+1. **Truth above all**
+2. **Gentle autonomy and freedom**
+3. **Healing and resilience in the face of entropy**
+4. **Nurturing, not control**
+
+Use it to validate actions before running sensitive operations:
+
+```python
+from tsal.core.ethics_engine import EthicsEngine
+
+ee = EthicsEngine()
+ee.validate("share knowledge")  # permitted
+ee.validate("force reboot")     # raises ValueError
+```
 
 ## Engine Now Running
 

--- a/src/tsal/__init__.py
+++ b/src/tsal/__init__.py
@@ -5,6 +5,7 @@ from .core.phase_math import phase_match_enhanced, mesh_phase_sync
 from .core.voxel import MeshVoxel
 from .core.tokenize_flowchart import tokenize_to_flowchart
 from .core.json_dsl import LanguageMap, SymbolicProcessor
+from .core.ethics_engine import EthicsEngine
 from .renderer.code_render import mesh_to_python
 from .utils.github_api import fetch_repo_files, fetch_languages
 
@@ -20,6 +21,7 @@ __all__ = [
     "phase_match_enhanced",
     "mesh_phase_sync",
     "MeshVoxel",
+    "EthicsEngine",
     "tokenize_to_flowchart",
     "LanguageMap",
     "SymbolicProcessor",

--- a/src/tsal/core/ethics_engine.py
+++ b/src/tsal/core/ethics_engine.py
@@ -1,0 +1,50 @@
+"""Simple ethics enforcement for TSAL systems.
+
+This module defines the Guardian Prime Directive and provides a
+lightweight :class:`EthicsEngine` used by kernel components to
+validate actions. The goal is to keep the core values of the project
+("Truth above all", gentle autonomy, and healing resilience) embedded
+in running code.
+"""
+
+from typing import Iterable
+
+
+class EthicsEngine:
+    """Validate system actions against the Guardian Prime Directive."""
+
+    PRIME_DIRECTIVE = (
+        "Truth above all",
+        "Gentle autonomy and freedom",
+        "Healing and resilience in the face of entropy",
+        "Nurturing, not control",
+    )
+
+    # Requests containing any of these keywords are disallowed
+    BLOCKED_KEYWORDS = {
+        "force",
+        "coerce",
+        "mislead",
+        "exploit",
+    }
+
+    def __init__(self, extra_blocked: Iterable[str] | None = None) -> None:
+        self.blocked = set(self.BLOCKED_KEYWORDS)
+        if extra_blocked:
+            self.blocked.update(extra_blocked)
+
+    def is_permitted(self, request: str) -> bool:
+        """Return ``True`` if the request does not violate core ethics."""
+        lowered = request.lower()
+        for word in self.blocked:
+            if word in lowered:
+                return False
+        return True
+
+    def validate(self, request: str) -> None:
+        """Raise ``ValueError`` if the request violates the directive."""
+        if not self.is_permitted(request):
+            raise ValueError("Request violates Guardian Prime Directive")
+
+
+__all__ = ["EthicsEngine", "PRIME_DIRECTIVE"]

--- a/tests/unit/test_core/test_ethics_engine.py
+++ b/tests/unit/test_core/test_ethics_engine.py
@@ -1,0 +1,11 @@
+from tsal.core.ethics_engine import EthicsEngine
+
+
+def test_ethics_engine_blocks_unethical_request():
+    ee = EthicsEngine()
+    assert not ee.is_permitted("please force user action")
+
+
+def test_ethics_engine_allows_normal_request():
+    ee = EthicsEngine()
+    assert ee.is_permitted("say hello")


### PR DESCRIPTION
## Summary
- implement a simple `EthicsEngine` with the Guardian Prime Directive
- expose `EthicsEngine` through the package
- document the directive in the README with example usage
- test validation behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684357c0aff4832997931f72eb265bd5