### PR TITLE
Implement SpiralVector logic

### DIFF
--- a/src/tsal/__init__.py
+++ b/src/tsal/__init__.py
@@ -5,6 +5,7 @@ from .core.phase_math import phase_match_enhanced, mesh_phase_sync
 from .core.voxel import MeshVoxel
 from .core.tokenize_flowchart import tokenize_to_flowchart
 from .core.json_dsl import LanguageMap, SymbolicProcessor
+from .core.spiral_vector import SpiralVector, phi_alignment
 from .core.ethics_engine import EthicsEngine
 from .renderer.code_render import mesh_to_python
 from .utils.github_api import fetch_repo_files, fetch_languages
@@ -25,6 +26,8 @@ __all__ = [
     "tokenize_to_flowchart",
     "LanguageMap",
     "SymbolicProcessor",
+    "SpiralVector",
+    "phi_alignment",
     "fetch_repo_files",
     "fetch_languages",
     "mesh_to_python",

--- a/src/tsal/core/spiral_vector.py
+++ b/src/tsal/core/spiral_vector.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""SpiralVector logic derived from legacy session logs."""
+
+from dataclasses import dataclass
+import hashlib
+
+from .symbols import PHI, PHI_INV
+
+
+def phi_alignment(complexity: float, coherence: float) -> float:
+    """Return φ-alignment score for given complexity and coherence."""
+    return (complexity * PHI_INV + coherence * PHI) / (PHI + PHI_INV)
+
+
+@dataclass
+class SpiralVector:
+    """Representation of a spiral code metric vector."""
+
+    name: str
+    complexity: float
+    coherence: float
+    intent: str
+
+    phi_signature: str = ""
+
+    def __post_init__(self) -> None:
+        self.phi_signature = self._calculate_phi_signature()
+
+    def _calculate_phi_signature(self) -> str:
+        content_hash = hashlib.sha256(
+            f"{self.name}{self.complexity}{self.coherence}".encode()
+        ).hexdigest()
+        phi_factor = (self.complexity * self.coherence) * PHI_INV
+        return f"φ^{phi_factor:.3f}_{content_hash[:8]}"
+
+    def alignment(self) -> float:
+        """Return the φ-alignment score for this vector."""
+        return phi_alignment(self.complexity, self.coherence)

--- a/tests/unit/test_core/test_spiral_vector.py
+++ b/tests/unit/test_core/test_spiral_vector.py
@@ -1,0 +1,15 @@
+from tsal.core.spiral_vector import SpiralVector, phi_alignment
+from tsal.core.symbols import PHI, PHI_INV
+
+
+def test_phi_alignment_calculation():
+    score = phi_alignment(1.0, 0.0)
+    expected = (1.0 * PHI_INV + 0.0 * PHI) / (PHI + PHI_INV)
+    assert abs(score - expected) < 1e-9
+
+
+def test_spiral_vector_signature_and_alignment():
+    vec = SpiralVector(name="foo", complexity=0.5, coherence=0.5, intent="test")
+    assert vec.phi_signature.startswith("φ^")
+    expected_align = phi_alignment(0.5, 0.5)
+    assert abs(vec.alignment() - expected_align) < 1e-9


### PR DESCRIPTION
## Summary
- add SpiralVector class and phi alignment helper
- export SpiralVector from `tsal` package
- test phi alignment and signature generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68435c3b14e88329820f196c65c542f1