### PR TITLE
Fix spiral bonus condition

### DIFF
--- a/src/tsal/core/phase_math.py
+++ b/src/tsal/core/phase_math.py
@@ -45,7 +45,7 @@ def phase_match_enhanced(
     # Spiral optimization - smaller corrections over time
     if mesh_context and "alignment_history" in mesh_context:
         history = mesh_context["alignment_history"]
-        if len(history) > 1 and abs(delta) < abs(history[-1]):
+        if history and abs(delta) < abs(history[-1]):
             # Converging spiral - energy bonus
             base_energy *= PHI_INV
 

--- a/tests/unit/test_core/test_phase_math.py
+++ b/tests/unit/test_core/test_phase_math.py
@@ -16,3 +16,10 @@ def test_mesh_phase_sync_structure():
     assert set(summary["nodes"].keys()) == set(nodes.keys())
     for info in summary["nodes"].values():
         assert {"initial", "final", "energy", "metrics"} <= info.keys()
+
+
+def test_spiral_bonus_applied_on_first_history_entry():
+    context = {"alignment_history": [10.0]}
+    baseline = phase_match_enhanced(5.0, 0.0)[1]
+    energy = phase_match_enhanced(5.0, 0.0, context)[1]
+    assert energy < baseline


### PR DESCRIPTION
## Summary
- apply spiral bonus even when there is only one previous delta
- check for this behaviour in `test_phase_math`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68436f8099fc832da28a80f634451244