### PR TITLE
Fix mesh_phase_sync empty node handling

### DIFF
--- a/src/tsal/core/phase_math.py
+++ b/src/tsal/core/phase_math.py
@@ -113,6 +113,13 @@ def mesh_phase_sync(
     nodes: Dict[str, float], universal_tempo: float, verbose: bool = False
 ) -> Dict[str, Any]:
     """Synchronize multiple nodes with mesh awareness"""
+    if not nodes:
+        return {
+            "nodes": {},
+            "total_energy": 0.0,
+            "mesh_resonance": 0.0,
+            "φ_signature": "φ^0.000_mesh",
+        }
     mesh_context = {"nodes_aligning": len(nodes), "alignment_history": []}
 
     results = {}

--- a/tests/unit/test_core/test_phase_math.py
+++ b/tests/unit/test_core/test_phase_math.py
@@ -23,3 +23,14 @@ def test_spiral_bonus_applied_on_first_history_entry():
     baseline = phase_match_enhanced(5.0, 0.0)[1]
     energy = phase_match_enhanced(5.0, 0.0, context)[1]
     assert energy < baseline
+
+
+def test_mesh_phase_sync_empty():
+    summary = mesh_phase_sync({}, 0.0)
+
+    assert summary == {
+        "nodes": {},
+        "total_energy": 0.0,
+        "mesh_resonance": 0.0,
+        "φ_signature": "φ^0.000_mesh",
+    }


### PR DESCRIPTION
## Summary
- avoid division by zero when calling `mesh_phase_sync` on an empty node set
- add regression test for empty node case

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684371e1bb70832d82d8a0b0b5130fe2