### PR TITLE
Add missing mesh_phase_sync empty dict test

### DIFF
--- a/tests/unit/test_core/test_phase_math.py
+++ b/tests/unit/test_core/test_phase_math.py
@@ -34,3 +34,14 @@ def test_mesh_phase_sync_empty():
         "mesh_resonance": 0.0,
         "φ_signature": "φ^0.000_mesh",
     }
+
+
+def test_mesh_phase_sync_empty_dict_arguments():
+    summary = mesh_phase_sync({}, {})
+
+    assert summary == {
+        "nodes": {},
+        "total_energy": 0.0,
+        "mesh_resonance": 0.0,
+        "φ_signature": "φ^0.000_mesh",
+    }


### PR DESCRIPTION
## Summary
- add a regression test for `mesh_phase_sync({},{})`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68438106fa18832d94d5601ec0304975