### PR TITLE
Add verbose coverage for empty mesh_phase_sync call

### DIFF
--- a/tests/unit/test_core/test_phase_math.py
+++ b/tests/unit/test_core/test_phase_math.py
@@ -45,3 +45,13 @@ def test_mesh_phase_sync_empty_dict_arguments():
         "mesh_resonance": 0.0,
         "φ_signature": "φ^0.000_mesh",
     }
+
+def test_mesh_phase_sync_empty_dict_with_verbose():
+    summary = mesh_phase_sync({}, {}, verbose=True)
+
+    assert summary == {
+        "nodes": {},
+        "total_energy": 0.0,
+        "mesh_resonance": 0.0,
+        "φ_signature": "φ^0.000_mesh",
+    }


### PR DESCRIPTION
## Summary
- cover `mesh_phase_sync` when both arguments are empty and verbose output is enabled

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684382d0a570832dbb6114650d563de4