### PR TITLE
Add mesh logger with tests

### DIFF
--- a/data/mesh_log_example.json
+++ b/data/mesh_log_example.json
@@ -1,0 +1,10 @@
+{
+  "timestamp": 1620000000.0,
+  "event_type": "TEST",
+  "phase": "init",
+  "payload": {
+    "foo": 1,
+    "bar": "baz"
+  },
+  "origin": "unit-test"
+}

--- a/data/mesh_log_schema.json
+++ b/data/mesh_log_schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Mesh Log Entry",
+  "type": "object",
+  "required": ["timestamp", "event_type", "payload"],
+  "properties": {
+    "timestamp": {"type": "number"},
+    "event_type": {"type": "string"},
+    "phase": {"type": "string"},
+    "payload": {"type": "object"},
+    "origin": {"type": "string"}
+  }
+}

--- a/src/tsal/core/__init__.py
+++ b/src/tsal/core/__init__.py
@@ -2,5 +2,6 @@
 
 from .rev_eng import Rev_Eng
 from .phase_math import phase_match_enhanced, mesh_phase_sync
+from .mesh_logger import log_event
 
-__all__ = ["Rev_Eng", "phase_match_enhanced", "mesh_phase_sync"]
+__all__ = ["Rev_Eng", "phase_match_enhanced", "mesh_phase_sync", "log_event"]

--- a/src/tsal/core/mesh_logger.py
+++ b/src/tsal/core/mesh_logger.py
@@ -1,0 +1,24 @@
+import json
+import time
+from pathlib import Path
+from typing import Dict, Any
+
+LOG_FILE = Path("data/mesh_log.jsonl")
+
+
+def log_event(event_type: str, payload: Dict[str, Any], phase: str | None = None, origin: str | None = None, verbose: bool = False) -> Dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValueError("payload must be a dict")
+    entry = {
+        "timestamp": time.time(),
+        "event_type": event_type,
+        "phase": phase or "unknown",
+        "payload": payload,
+        "origin": origin or "core",
+    }
+    LOG_FILE.parent.mkdir(exist_ok=True)
+    with LOG_FILE.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry) + "\n")
+    if verbose:
+        print(json.dumps(entry))
+    return entry

--- a/src/tsal/core/phase_math.py
+++ b/src/tsal/core/phase_math.py
@@ -2,6 +2,8 @@ import math
 import time
 from typing import Tuple, Dict, Any
 
+from .mesh_logger import log_event
+
 # TSAL Mathematical Constants
 PHI = 1.618033988749895
 PHI_INV = 0.618033988749895
@@ -101,9 +103,14 @@ def log_energy_use_enhanced(
             "gift": "Phase mismatch reveals new harmonic possibility",
         }
 
-    # Log to mesh (placeholder - would connect to actual mesh)
-    if verbose:
-        print(f"⚡ Energy: {energy:.3f} | {metrics['phase_signature']}")
+    # Log to mesh
+    log_event(
+        "ENERGY_USE",
+        log_entry,
+        phase="energy",
+        origin="phase_math",
+        verbose=verbose,
+    )
 
     return log_entry
 

--- a/tests/unit/test_core/test_mesh_logger.py
+++ b/tests/unit/test_core/test_mesh_logger.py
@@ -1,0 +1,32 @@
+import json
+import sys
+import types
+
+import pytest
+
+requests_stub = types.SimpleNamespace(get=lambda *a, **k: None, HTTPError=Exception)
+yaml_stub = types.SimpleNamespace(safe_load=lambda *a, **k: {})
+sys.modules.setdefault("requests", requests_stub)
+sys.modules.setdefault("yaml", yaml_stub)
+
+from tsal.core import mesh_logger
+from tsal.core.mesh_logger import log_event
+
+
+def test_log_event_writes(tmp_path, monkeypatch):
+    log_file = tmp_path / "mesh.jsonl"
+    monkeypatch.setattr(mesh_logger, "LOG_FILE", log_file)
+    entry = log_event("TEST", {"foo": 1}, verbose=False)
+    data = log_file.read_text().strip().splitlines()
+    assert len(data) == 1
+    saved = json.loads(data[0])
+    assert saved["event_type"] == "TEST"
+    assert saved["payload"] == {"foo": 1}
+    assert "timestamp" in saved
+
+
+def test_log_event_invalid(tmp_path, monkeypatch):
+    log_file = tmp_path / "mesh.jsonl"
+    monkeypatch.setattr(mesh_logger, "LOG_FILE", log_file)
+    with pytest.raises(ValueError):
+        log_event("BAD", "not a dict")


### PR DESCRIPTION
## Summary
- define JSON schema and example for mesh logs
- implement `mesh_logger.log_event` and expose via core package
- hook logger into `phase_math.log_energy_use_enhanced`
- add unit tests for the logger

## Testing
- `pip install requests PyYAML`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843658b1b7c8329979c01f5598847ee