### PR TITLE
Add Rev_Eng integration to SymbolicProcessor

### DIFF
--- a/tests/unit/test_utils/test_json_dsl.py
+++ b/tests/unit/test_utils/test_json_dsl.py
@@ -1,4 +1,5 @@
 from tsal.core.json_dsl import LanguageMap, SymbolicProcessor
+from tsal.core.rev_eng import Rev_Eng
 
 
 def test_language_map_roundtrip(tmp_path):
@@ -12,10 +13,12 @@ def test_language_map_roundtrip(tmp_path):
 
 def test_symbolic_processor_encode_decode():
     lang = LanguageMap(language="py", ops=[{"keyword": "def", "type": "function"}])
-    sp = SymbolicProcessor(lang)
+    rev = Rev_Eng(origin="test")
+    sp = SymbolicProcessor(lang, rev_eng=rev)
     lines = ["def test():", "    pass"]
     tokens = sp.decode(lines)
     assert tokens[0]["type"] == "function"
     out = sp.encode(tokens)
     assert "def test():" in out
+    assert rev.data_stats["chunk_count"] == 3  # two lines in, one block out
 


### PR DESCRIPTION
## Summary
- hook `SymbolicProcessor` to `Rev_Eng` for real-time logging
- update tests for new tracking behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68439fcee8c4832d81f2898710c0dcf4