### PR TITLE
Add real_time_codec helper

### DIFF
--- a/deployed_kernels/src/tsal/tools/__init__.py
+++ b/deployed_kernels/src/tsal/tools/__init__.py
@@ -1,0 +1,4 @@
+from .codec import real_time_codec
+from .brian import SymbolicOptimizer, analyze_and_repair
+
+__all__ = ["real_time_codec", "SymbolicOptimizer", "analyze_and_repair"]

--- a/deployed_kernels/src/tsal/tools/codec.py
+++ b/deployed_kernels/src/tsal/tools/codec.py
@@ -1,0 +1,26 @@
+"""Real-time decode/encode helper."""
+
+from typing import Iterable, Callable, Optional
+from importlib import resources
+
+from tsal.core.json_dsl import LanguageMap, SymbolicProcessor
+from tsal.core.rev_eng import Rev_Eng
+
+
+def real_time_codec(
+    lines: Iterable[str],
+    schema: str | None = None,
+    transform: Optional[Callable[[list[dict]], list[dict]]] = None,
+    rev: Optional[Rev_Eng] = None,
+) -> str:
+    """Decode lines, run an optional token transform, encode result."""
+    if schema is None:
+        schema = str(resources.files("tsal.schemas").joinpath("python.json"))
+    lang = LanguageMap.load(schema)
+    rev = rev or Rev_Eng(origin="real_time_codec")
+    sp = SymbolicProcessor(lang, rev_eng=rev)
+    source = list(lines)
+    tokens = sp.decode(source)
+    if transform:
+        tokens = transform(tokens)
+    return sp.encode(tokens)

--- a/src/tsal/tools/__init__.py
+++ b/src/tsal/tools/__init__.py
@@ -1,0 +1,4 @@
+from .codec import real_time_codec
+from .brian import SymbolicOptimizer, analyze_and_repair
+
+__all__ = ["real_time_codec", "SymbolicOptimizer", "analyze_and_repair"]

--- a/src/tsal/tools/codec.py
+++ b/src/tsal/tools/codec.py
@@ -1,0 +1,32 @@
+"""Real-time decode/encode helper."""
+
+from typing import Iterable, Callable, Optional
+from importlib import resources
+
+from tsal.core.json_dsl import LanguageMap, SymbolicProcessor
+from tsal.core.rev_eng import Rev_Eng
+
+
+def real_time_codec(
+    lines: Iterable[str],
+    schema: str | None = None,
+    transform: Optional[Callable[[list[dict]], list[dict]]] = None,
+    rev: Optional[Rev_Eng] = None,
+) -> str:
+    """Decode lines, run an optional token transform, encode result.
+
+    ``lines`` is any iterable yielding code lines. If ``schema`` is not
+    provided, the built-in Python schema is used. ``transform`` receives the
+    token list before encoding. ``rev`` logs byte counts for in/out data.
+    """
+    if schema is None:
+        schema = str(resources.files("tsal.schemas").joinpath("python.json"))
+    lang = LanguageMap.load(schema)
+    rev = rev or Rev_Eng(origin="real_time_codec")
+    sp = SymbolicProcessor(lang, rev_eng=rev)
+
+    source = list(lines)
+    tokens = sp.decode(source)
+    if transform:
+        tokens = transform(tokens)
+    return sp.encode(tokens)

--- a/tests/unit/test_tools/test_codec.py
+++ b/tests/unit/test_tools/test_codec.py
@@ -1,0 +1,22 @@
+from importlib import resources
+from tsal.tools.codec import real_time_codec
+from tsal.core.rev_eng import Rev_Eng
+
+
+def test_real_time_codec_roundtrip():
+    lines = ["def a():", "    return 1"]
+    schema = str(resources.files("tsal.schemas").joinpath("python.json"))
+    rev = Rev_Eng(origin="test")
+    out = real_time_codec(lines, schema=schema, rev=rev)
+    assert "def a():" in out
+    assert rev.data_stats["chunk_count"] == len(lines) + 1
+
+
+def test_real_time_codec_transform():
+    lines = ["def a():", "    return 1"]
+    schema = str(resources.files("tsal.schemas").joinpath("python.json"))
+    def tweak(tokens):
+        tokens[-1]["raw"] = "    return 2"
+        return tokens
+    out = real_time_codec(lines, schema=schema, transform=tweak)
+    assert "return 2" in out


### PR DESCRIPTION
## Summary
- expose a new `real_time_codec` helper
- keep tool exports in sync
- test the new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6843a350f414832dab3f4fd70ab9cc2c