### PR TITLE
Implement phi-field math

### DIFF
--- a/src/tsal/__init__.py
+++ b/src/tsal/__init__.py
@@ -2,6 +2,12 @@
 
 from .core.rev_eng import Rev_Eng
 from .core.phase_math import phase_match_enhanced, mesh_phase_sync
+from .core.phi_math import (
+    phi_wavefunction,
+    phase_alignment_potential,
+    corrected_energy,
+    orbital_radius,
+)
 from .core.voxel import MeshVoxel
 from .core.tokenize_flowchart import tokenize_to_flowchart
 from .core.json_dsl import LanguageMap, SymbolicProcessor
@@ -21,6 +27,10 @@ __all__ = [
     "Rev_Eng",
     "phase_match_enhanced",
     "mesh_phase_sync",
+    "phi_wavefunction",
+    "phase_alignment_potential",
+    "corrected_energy",
+    "orbital_radius",
     "MeshVoxel",
     "EthicsEngine",
     "tokenize_to_flowchart",

--- a/src/tsal/core/__init__.py
+++ b/src/tsal/core/__init__.py
@@ -2,6 +2,21 @@
 
 from .rev_eng import Rev_Eng
 from .phase_math import phase_match_enhanced, mesh_phase_sync
+from .phi_math import (
+    phi_wavefunction,
+    phase_alignment_potential,
+    corrected_energy,
+    orbital_radius,
+)
 from .mesh_logger import log_event
 
-__all__ = ["Rev_Eng", "phase_match_enhanced", "mesh_phase_sync", "log_event"]
+__all__ = [
+    "Rev_Eng",
+    "phase_match_enhanced",
+    "mesh_phase_sync",
+    "phi_wavefunction",
+    "phase_alignment_potential",
+    "corrected_energy",
+    "orbital_radius",
+    "log_event",
+]

--- a/src/tsal/core/phi_math.py
+++ b/src/tsal/core/phi_math.py
@@ -1,0 +1,42 @@
+"""Phi-field correction equations.
+
+© 2025 Samuel Edward Howells. All rights reserved.
+- Open for non-commercial academic and research use.
+- Commercial use, redistribution, or integration into proprietary models requires written permission from the author.
+- For inquiries, contact via the project page.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def phi_wavefunction(phi: float, phi_vacuum: float = 0.0, lam: float = 1.0) -> float:
+    """Return ψ(φ) = exp((φ - φ_vacuum) / λ)."""
+    return math.exp((phi - phi_vacuum) / lam)
+
+
+def phase_alignment_potential(phi: float, phi_vacuum: float = 0.0, lam: float = 1.0) -> float:
+    """Return g(φ) = 2 * exp((φ - φ_vacuum) / λ)."""
+    return 2.0 * phi_wavefunction(phi, phi_vacuum, lam)
+
+
+def corrected_energy(n: int, phi: float, phi_vacuum: float = 0.0, lam: float = 1.0) -> float:
+    """Return E_n = -g(φ) / n²."""
+    g_val = phase_alignment_potential(phi, phi_vacuum, lam)
+    return -g_val / float(n * n)
+
+
+def orbital_radius(n: int, phi: float, phi_vacuum: float = 0.0, lam: float = 1.0) -> float:
+    """Return r_n ≈ n² / g(φ)."""
+    g_val = phase_alignment_potential(phi, phi_vacuum, lam)
+    return (n * n) / g_val
+
+
+__all__ = [
+    "phi_wavefunction",
+    "phase_alignment_potential",
+    "corrected_energy",
+    "orbital_radius",
+]
+

--- a/tests/unit/test_core/test_phi_math.py
+++ b/tests/unit/test_core/test_phi_math.py
@@ -1,0 +1,27 @@
+from math import exp
+
+from tsal.core.phi_math import (
+    phi_wavefunction,
+    phase_alignment_potential,
+    corrected_energy,
+    orbital_radius,
+)
+
+
+def test_phi_wavefunction_basic():
+    assert phi_wavefunction(1.0, 0.0, 2.0) == exp((1.0 - 0.0) / 2.0)
+
+
+def test_phase_alignment_potential_doubles_wavefunction():
+    val = phi_wavefunction(0.5)
+    assert phase_alignment_potential(0.5) == 2 * val
+
+
+def test_corrected_energy():
+    g_val = phase_alignment_potential(0.1)
+    assert corrected_energy(2, 0.1) == -g_val / 4.0
+
+
+def test_orbital_radius():
+    g_val = phase_alignment_potential(0.2)
+    assert orbital_radius(3, 0.2) == 9.0 / g_val


### PR DESCRIPTION
## Summary
- add phi-field correction module with wavefunction, potential, energy, and radius equations
- expose phi-field math in package exports
- cover new functions with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6843a8ebb6bc832da18a43555a30c6bd