### PR TITLE
add voxel logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ python -m tsal.utils.language_db
 This creates `system_io.db` containing a `languages` table with all entries.
 
 This data can be supplied to Brian's optimizer when analyzing or repairing code.
+Every call to `Rev_Eng.log_data` now records a voxel (pace, rate, state, spin)
+and tracks XOR/NAND spin collisions.
 ## Quickstart
 1. Put your input code in `examples/broken_code.py`
 2. Run `python examples/mesh_pipeline_demo.py`

--- a/tests/unit/test_core/test_rev_eng.py
+++ b/tests/unit/test_core/test_rev_eng.py
@@ -1,13 +1,18 @@
 from tsal.core.rev_eng import Rev_Eng
+from tsal.core import mesh_logger
 
 
-def test_log_and_summary(tmp_path):
-    rev = Rev_Eng(origin="test")
-    rev.log_data(10, direction="in")
-    rev.log_event("ACTION", detail=1)
-    rev.update_mesh_coords(x=1, y=2)
+def test_log_data_and_summary(tmp_path, monkeypatch):
+    log_file = tmp_path / "log.jsonl"
+    monkeypatch.setattr(mesh_logger, "LOG_FILE", log_file)
+    rev = Rev_Eng(origin="unit")
+    start_bytes = rev.data_stats["total_bytes"]
+    rev.log_data(10, direction="in", updown="up")
+    rev.log_data(5, direction="out", updown="down")
+    assert rev.data_stats["total_bytes"] == start_bytes + 15
     summary = rev.summary()
-    assert summary["origin"] == "test"
-    assert summary["data_stats"]["total_bytes"] == 10
-    assert summary["event_count"] == 1
-    assert summary["mesh_coords"]["x"] == 1
+    assert summary["event_count"] == 0  # log_data only updates spin_log
+    assert summary["data_stats"]["chunk_count"] == 2
+    assert summary["collisions"]["xor"] == 1
+    assert len(summary["voxels"]) == 2
+    assert log_file.exists()


### PR DESCRIPTION
## Summary
- track spin collisions in `Rev_Eng`
- emit voxels for `log_data`
- test the new behaviour
- document logging in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6843b52e33a4832daae2870f85a92274