### PR TITLE
Add IDM calculation

### DIFF
--- a/src/tsal/core/__init__.py
+++ b/src/tsal/core/__init__.py
@@ -9,6 +9,7 @@ from .phi_math import (
     orbital_radius,
 )
 from .mesh_logger import log_event
+from .intent_metric import calculate_idm
 
 __all__ = [
     "Rev_Eng",
@@ -19,4 +20,5 @@ __all__ = [
     "corrected_energy",
     "orbital_radius",
     "log_event",
+    "calculate_idm",
 ]

--- a/src/tsal/core/intent_metric.py
+++ b/src/tsal/core/intent_metric.py
@@ -1,0 +1,13 @@
+"""Intent-Driven Metric calculation."""
+
+
+def calculate_idm(info_quality: float, info_quantity: float, accuracy: float,
+                   complexity: float, time_taken: float) -> float:
+    """Return the IDM score.
+
+    IDM = (info_quality * info_quantity * accuracy) / (complexity * time_taken)
+    """
+    if complexity <= 0 or time_taken <= 0:
+        raise ValueError("complexity and time_taken must be > 0")
+    info_power = info_quality * info_quantity * accuracy
+    return info_power / (complexity * time_taken)

--- a/tests/unit/test_core/test_intent_metric.py
+++ b/tests/unit/test_core/test_intent_metric.py
@@ -1,0 +1,12 @@
+from tsal.core.intent_metric import calculate_idm
+import pytest
+
+
+def test_calculate_idm_basic():
+    score = calculate_idm(0.9, 10, 0.95, 50, 0.8)
+    assert abs(score - 0.21375) < 1e-6
+
+
+def test_calculate_idm_invalid():
+    with pytest.raises(ValueError):
+        calculate_idm(1.0, 1.0, 1.0, 0.0, 1.0)


### PR DESCRIPTION
## Summary
- implement `calculate_idm` for the Intent-Driven Metric
- expose function via `tsal.core`
- test basic and error cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6843b49c16fc832db38e6c68567e2726