### PR TITLE
Add intent metric utilities

### DIFF
--- a/src/tsal/utils/__init__.py
+++ b/src/tsal/utils/__init__.py
@@ -2,5 +2,13 @@
 
 from .error_dignity import activate_error_dignity
 from .github_api import fetch_repo_files, fetch_languages
+from .intent_metrics import calculate_idm, MetricInputs, timed_idm
 
-__all__ = ["activate_error_dignity", "fetch_repo_files", "fetch_languages"]
+__all__ = [
+    "activate_error_dignity",
+    "fetch_repo_files",
+    "fetch_languages",
+    "calculate_idm",
+    "MetricInputs",
+    "timed_idm",
+]

--- a/src/tsal/utils/intent_metrics.py
+++ b/src/tsal/utils/intent_metrics.py
@@ -1,0 +1,47 @@
+"""Intent-driven metric calculation utilities."""
+
+from dataclasses import dataclass
+import time
+from typing import Callable, Any, Tuple
+
+
+@dataclass
+class MetricInputs:
+    quality: float
+    quantity: float
+    accuracy: float
+    complexity: float
+
+
+def calculate_idm(
+    quality: float,
+    quantity: float,
+    accuracy: float,
+    complexity: float,
+    time_taken: float,
+) -> float:
+    """Compute the intent-driven metric."""
+    if complexity <= 0 or time_taken <= 0:
+        raise ValueError("complexity and time_taken must be positive")
+    info_power = quality * quantity * accuracy
+    return info_power / (complexity * time_taken)
+
+
+def timed_idm(
+    inputs: MetricInputs,
+    fn: Callable[..., Any],
+    *args: Any,
+    **kwargs: Any,
+) -> Tuple[float, Any]:
+    """Time a function call and compute IDM using provided inputs."""
+    start = time.time()
+    result = fn(*args, **kwargs)
+    duration = time.time() - start
+    score = calculate_idm(
+        inputs.quality,
+        inputs.quantity,
+        inputs.accuracy,
+        inputs.complexity,
+        duration,
+    )
+    return score, result

--- a/tests/unit/test_utils/test_intent_metrics.py
+++ b/tests/unit/test_utils/test_intent_metrics.py
@@ -1,0 +1,19 @@
+from tsal.utils.intent_metrics import calculate_idm, MetricInputs, timed_idm
+
+
+def dummy_fn(x):
+    return x * 2
+
+
+def test_calculate_idm_basic():
+    score = calculate_idm(1.0, 10, 0.8, 5, 0.5)
+    assert round(score, 3) == round((1.0 * 10 * 0.8) / (5 * 0.5), 3)
+
+
+def test_timed_idm(monkeypatch):
+    calls = iter([0, 0.1])
+    monkeypatch.setattr('time.time', lambda: next(calls))
+    inputs = MetricInputs(quality=1.0, quantity=2.0, accuracy=0.5, complexity=1.0)
+    score, result = timed_idm(inputs, dummy_fn, 3)
+    assert result == 6
+    assert score > 0


### PR DESCRIPTION
## Summary
- implement `intent_metrics` module with IDM calculation
- expose metric functions via utils
- test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6843bc5da29c832dae2289e808d9834a