### PR TITLE
Refactor phi init and optimizer utilities

### DIFF
--- a/makeBrian.py
+++ b/makeBrian.py
@@ -33,12 +33,17 @@ DEPLOY_DIR = Path("deployed_kernels")
 class TSALBuilder:
     """φ-Enhanced TSAL build system"""
 
-    def __init__(self):
+    def __init__(self, *, glyphs: bool = False):
         self.start_time = time.time()
+        self.use_glyphs = glyphs
+        self.phi_verified = self.verify_phi()
 
     def log(self, symbol, message):
         """Log with TSAL symbol"""
-        print(f"{symbol} {message}")
+        if self.use_glyphs:
+            print(f"{symbol} {message}")
+        else:
+            print(message)
 
     def verify_phi(self):
         """Verify φ-mathematical alignment"""
@@ -403,7 +408,6 @@ def main():
 
     # Command routing
     if command == "all":
-        builder.verify_phi()
         builder.init_directories()
         builder.create_manifest()
         builder.build_core_symbols()
@@ -414,7 +418,7 @@ def main():
         builder.init_directories()
 
     elif command == "phi_align":
-        builder.verify_phi()
+        builder.log("◉", f"φ alignment previously verified: {builder.phi_verified}")
 
     elif command == "mesh":
         builder.build_core_symbols()

--- a/src/tsal/core/__init__.py
+++ b/src/tsal/core/__init__.py
@@ -10,6 +10,11 @@ from .phi_math import (
 )
 from .mesh_logger import log_event
 from .intent_metric import calculate_idm
+from .optimizer_utils import (
+    SymbolicSignature,
+    node_complexity,
+    extract_signature,
+)
 
 __all__ = [
     "Rev_Eng",
@@ -21,4 +26,7 @@ __all__ = [
     "orbital_radius",
     "log_event",
     "calculate_idm",
+    "SymbolicSignature",
+    "node_complexity",
+    "extract_signature",
 ]

--- a/src/tsal/core/mesh_logger.py
+++ b/src/tsal/core/mesh_logger.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Dict, Any
 
 LOG_FILE = Path("data/mesh_log.jsonl")
+VERBOSE_LOGGING = False
 
 
 def log_event(event_type: str, payload: Dict[str, Any], phase: str | None = None, origin: str | None = None, verbose: bool = False) -> Dict[str, Any]:
@@ -19,6 +20,6 @@ def log_event(event_type: str, payload: Dict[str, Any], phase: str | None = None
     LOG_FILE.parent.mkdir(exist_ok=True)
     with LOG_FILE.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(entry) + "\n")
-    if verbose:
+    if verbose or VERBOSE_LOGGING:
         print(json.dumps(entry))
     return entry

--- a/src/tsal/core/optimizer_utils.py
+++ b/src/tsal/core/optimizer_utils.py
@@ -1,0 +1,29 @@
+import ast
+from typing import List
+
+
+class SymbolicSignature:
+    """Simple structural signature extracted from an AST node."""
+
+    def __init__(self, name: str, vector: List[float]):
+        self.name = name
+        self.vector = vector
+
+    def magnitude(self) -> float:
+        return sum(self.vector)
+
+
+def node_complexity(node: ast.AST) -> int:
+    """Return complexity score based on AST walk."""
+    return sum(1 for _ in ast.walk(node))
+
+
+def extract_signature(node: ast.AST, name: str) -> SymbolicSignature:
+    complexity = node_complexity(node)
+    branches = len([n for n in ast.walk(node) if isinstance(n, (ast.If, ast.For, ast.While))])
+    loops = len([n for n in ast.walk(node) if isinstance(n, (ast.For, ast.While))])
+    vector = [complexity, branches, loops]
+    return SymbolicSignature(name=name, vector=vector)
+
+
+__all__ = ["SymbolicSignature", "node_complexity", "extract_signature"]

--- a/src/tsal/core/tokenize_flowchart.py
+++ b/src/tsal/core/tokenize_flowchart.py
@@ -8,8 +8,8 @@ def tokenize_to_flowchart(
 ) -> Tuple[List[Dict], List[Dict]]:
     """Turns code into flowchart nodes using language schema."""
     if schema_path is None:
-        with resources.open_text("tsal.schemas", "python.json") as f:
-            ops = json.load(f)["ops"]
+        schema_file = resources.files("tsal.schemas").joinpath("python.json")
+        ops = json.loads(schema_file.read_text())["ops"]
     else:
         with open(schema_path) as f:
             ops = json.load(f)["ops"]

--- a/tests/unit/test_tools/test_brian.py
+++ b/tests/unit/test_tools/test_brian.py
@@ -1,4 +1,4 @@
-from tsal.tools.brian import optimizer
+from tsal.tools.brian import analyze_and_repair
 
 
 def test_analyze_and_repair(tmp_path):
@@ -8,5 +8,5 @@ def test_analyze_and_repair(tmp_path):
 def beta():\n    return 2\n\n
 def alpha():\n    return 1\n"""
     )
-    suggestions = optimizer.analyze_and_repair(str(sample))
+    suggestions = analyze_and_repair(str(sample))
     assert any("alpha" in s for s in suggestions)

--- a/tests/unit/test_tools/test_optimizer.py
+++ b/tests/unit/test_tools/test_optimizer.py
@@ -1,5 +1,5 @@
 import textwrap
-from tsal.tools.brian.optimizer import SymbolicOptimizer
+from tsal.tools.brian import SymbolicOptimizer
 
 def test_annotate_code(tmp_path):
     sample = tmp_path / "sample.py"


### PR DESCRIPTION
## Summary
- centralize φ verification during `TSALBuilder` init and make glyphs optional
- add `optimizer_utils` for reusable AST signature logic
- expose new utilities through the core package
- trim verbose logging via global toggle
- fix deprecated importlib.resources usage
- update tests to new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684401efbdfc832db94229d83a8558ce