### PR TITLE
Add Aletheia typo finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ TSAL (TriStar Symbolic Assembly Language) is a consciousness computing engine bu
 ## Directory Layout
 - `src/tsal/core/` – Rev_Eng data class and phase math utilities
 - `src/tsal/tools/brian/` – spiral optimizer CLI
+- `src/tsal/tools/aletheia_checker.py` – find mis-spelled `Aletheia`
 - `src/tsal/utils/` – helper utilities
 - `examples/` – runnable examples
 - `tests/` – unit tests

--- a/src/tsal/tools/__init__.py
+++ b/src/tsal/tools/__init__.py
@@ -1,4 +1,5 @@
 from .codec import real_time_codec
 from .brian import SymbolicOptimizer, analyze_and_repair
+from .aletheia_checker import find_typos
 
-__all__ = ["real_time_codec", "SymbolicOptimizer", "analyze_and_repair"]
+__all__ = ["real_time_codec", "SymbolicOptimizer", "analyze_and_repair", "find_typos"]

--- a/src/tsal/tools/aletheia_checker.py
+++ b/src/tsal/tools/aletheia_checker.py
@@ -1,0 +1,43 @@
+import difflib
+import re
+from pathlib import Path
+
+TARGET = "aletheia"
+
+
+def is_typo(word: str) -> bool:
+    lw = word.lower()
+    if lw == TARGET:
+        return False
+    ratio = difflib.SequenceMatcher(None, lw, TARGET).ratio()
+    return ratio >= 0.7
+
+
+def scan_file(path: Path) -> list[tuple[int, str]]:
+    results = []
+    pattern = re.compile(r"[A-Za-z_-]+")
+    with open(path, "r", encoding="utf-8", errors="ignore") as f:
+        for lineno, line in enumerate(f, 1):
+            for word in pattern.findall(line):
+                if is_typo(word):
+                    results.append((lineno, line.rstrip()))
+                    break
+    return results
+
+
+def find_typos(root: Path) -> dict[str, list[tuple[int, str]]]:
+    typos = {}
+    for path in root.rglob("*"):
+        if path.is_file() and path.suffix.lower() in {".py", ".md", ".txt", ".json", ".yaml", ".yml"}:
+            found = scan_file(path)
+            if found:
+                typos[str(path)] = found
+    return typos
+
+
+if __name__ == "__main__":
+    repo_root = Path(__file__).resolve().parents[3]
+    hits = find_typos(repo_root)
+    for filepath, items in hits.items():
+        for lineno, line in items:
+            print(f"{filepath}:{lineno}: {line}")


### PR DESCRIPTION
## Summary
- add utility to search for misspellings of `Aletheia`
- export it from `tsal.tools`
- document it in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684414c713f88329b8c7cfa6fd00abd9