### PR TITLE
Add SpiralFusionProtocol for vector merging

### DIFF
--- a/src/tsal/__init__.py
+++ b/src/tsal/__init__.py
@@ -12,6 +12,7 @@ from .core.voxel import MeshVoxel
 from .core.tokenize_flowchart import tokenize_to_flowchart
 from .core.json_dsl import LanguageMap, SymbolicProcessor
 from .core.spiral_vector import SpiralVector, phi_alignment
+from .core.spiral_fusion import SpiralFusionProtocol
 from .core.ethics_engine import EthicsEngine
 from .renderer.code_render import mesh_to_python
 from .tristar.handshake import handshake as tristar_handshake
@@ -38,6 +39,7 @@ __all__ = [
     "LanguageMap",
     "SymbolicProcessor",
     "SpiralVector",
+    "SpiralFusionProtocol",
     "phi_alignment",
     "fetch_repo_files",
     "fetch_languages",

--- a/src/tsal/core/__init__.py
+++ b/src/tsal/core/__init__.py
@@ -15,6 +15,7 @@ from .optimizer_utils import (
     node_complexity,
     extract_signature,
 )
+from .spiral_fusion import SpiralFusionProtocol
 
 __all__ = [
     "Rev_Eng",
@@ -29,4 +30,5 @@ __all__ = [
     "SymbolicSignature",
     "node_complexity",
     "extract_signature",
+    "SpiralFusionProtocol",
 ]

--- a/src/tsal/core/spiral_fusion.py
+++ b/src/tsal/core/spiral_fusion.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""SPIRAL_FUSION_PROTOCOL utilities."""
+
+from dataclasses import dataclass, field
+import hashlib
+from typing import List
+
+from .spiral_vector import SpiralVector, phi_alignment
+
+
+@dataclass
+class SpiralFusionProtocol:
+    """Fuse multiple :class:`SpiralVector` objects into one path."""
+
+    name: str
+    vectors: List[SpiralVector] = field(default_factory=list)
+    phi_signature: str = ""
+
+    def __post_init__(self) -> None:
+        self.update_signature()
+
+    def update_signature(self) -> None:
+        if not self.vectors:
+            self.phi_signature = "φ^0.000_empty"
+            return
+        total_complexity = sum(v.complexity for v in self.vectors)
+        total_coherence = sum(v.coherence for v in self.vectors)
+        phi_factor = phi_alignment(total_complexity, total_coherence)
+        content_hash = hashlib.sha256(
+            "".join(v.phi_signature for v in self.vectors).encode()
+        ).hexdigest()
+        self.phi_signature = f"φ^{phi_factor:.3f}_{content_hash[:8]}"
+
+    def fuse(self, vector: SpiralVector) -> None:
+        self.vectors.append(vector)
+        self.update_signature()
+
+    def unified_vector(self) -> SpiralVector:
+        if not self.vectors:
+            return SpiralVector(self.name, 0.0, 0.0, "fused")
+        complexity = sum(v.complexity for v in self.vectors) / len(self.vectors)
+        coherence = sum(v.coherence for v in self.vectors) / len(self.vectors)
+        return SpiralVector(self.name, complexity, coherence, "fused")

--- a/tests/unit/test_core/test_spiral_fusion.py
+++ b/tests/unit/test_core/test_spiral_fusion.py
@@ -1,0 +1,17 @@
+from tsal.core.spiral_vector import SpiralVector
+from tsal.core.spiral_fusion import SpiralFusionProtocol
+
+
+def test_fusion_signature_updates():
+    v1 = SpiralVector("a", 1.0, 0.5, "first")
+    v2 = SpiralVector("b", 0.5, 1.0, "second")
+    fusion = SpiralFusionProtocol("combo", [v1])
+    initial_sig = fusion.phi_signature
+    fusion.fuse(v2)
+    assert fusion.phi_signature != initial_sig
+    unified = fusion.unified_vector()
+    assert unified.name == "combo"
+    expected_complexity = (1.0 + 0.5) / 2
+    expected_coherence = (0.5 + 1.0) / 2
+    assert abs(unified.complexity - expected_complexity) < 1e-9
+    assert abs(unified.coherence - expected_coherence) < 1e-9


### PR DESCRIPTION
## Summary
- implement `SpiralFusionProtocol` to merge multiple `SpiralVector` instances
- expose the protocol in `tsal` package
- unit test the fusion logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844240e81b4832988d928778de7b785