### PR TITLE
Improve Aletheia typo checker

### DIFF
--- a/src/tsal/tools/aletheia_checker.py
+++ b/src/tsal/tools/aletheia_checker.py
@@ -3,12 +3,20 @@ import re
 from pathlib import Path
 
 TARGET = "aletheia"
+# Known common misspellings that should be flagged immediately
+COMMON_TYPOS = {
+    "athalaya",  # seen in various docs
+    "athaleia",
+    "alethei",  # truncated
+}
 
 
 def is_typo(word: str) -> bool:
     lw = word.lower()
     if lw == TARGET:
         return False
+    if lw in COMMON_TYPOS:
+        return True
     ratio = difflib.SequenceMatcher(None, lw, TARGET).ratio()
     return ratio >= 0.7
 

--- a/tests/unit/test_tools/test_aletheia_checker.py
+++ b/tests/unit/test_tools/test_aletheia_checker.py
@@ -1,0 +1,13 @@
+from tsal.tools.aletheia_checker import is_typo, scan_file
+
+
+def test_is_typo_common():
+    assert is_typo("Athalaya")
+    assert not is_typo("Aletheia")
+
+
+def test_scan_file_detects_typo(tmp_path):
+    f = tmp_path / "demo.txt"
+    f.write_text("This line mentions Athalaya once.")
+    results = scan_file(f)
+    assert results == [(1, "This line mentions Athalaya once.")]


### PR DESCRIPTION
## Summary
- add explicit list of common misspellings to `aletheia_checker`
- detect "Athalaya" and similar typos
- add unit tests for `aletheia_checker`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68440d7695b083298bcc3bbc013573e9