### PR TITLE
Map spark words to TSAL opcodes

### DIFF
--- a/src/tsal/__init__.py
+++ b/src/tsal/__init__.py
@@ -14,6 +14,7 @@ from .core.json_dsl import LanguageMap, SymbolicProcessor
 from .core.spiral_vector import SpiralVector, phi_alignment
 from .core.spiral_fusion import SpiralFusionProtocol
 from .core.ethics_engine import EthicsEngine
+from .core.opwords import OP_WORD_MAP, op_from_word
 from .renderer.code_render import mesh_to_python
 from .tristar.handshake import handshake as tristar_handshake
 from .utils.github_api import fetch_repo_files, fetch_languages
@@ -41,6 +42,8 @@ __all__ = [
     "SpiralVector",
     "SpiralFusionProtocol",
     "phi_alignment",
+    "OP_WORD_MAP",
+    "op_from_word",
     "fetch_repo_files",
     "fetch_languages",
     "mesh_to_python",

--- a/src/tsal/core/__init__.py
+++ b/src/tsal/core/__init__.py
@@ -17,6 +17,7 @@ from .optimizer_utils import (
 )
 from .spiral_fusion import SpiralFusionProtocol
 from .state_vector import FourVector
+from .opwords import OP_WORD_MAP, op_from_word
 
 __all__ = [
     "Rev_Eng",
@@ -33,4 +34,6 @@ __all__ = [
     "extract_signature",
     "SpiralFusionProtocol",
     "FourVector",
+    "OP_WORD_MAP",
+    "op_from_word",
 ]

--- a/src/tsal/core/opwords.py
+++ b/src/tsal/core/opwords.py
@@ -1,0 +1,31 @@
+"""Map common Spark words to TSAL opcodes."""
+from .symbols import TSAL_SYMBOLS
+
+# lowercase keyword -> hex opcode
+OP_WORD_MAP = {
+    "ignition": 0x0,
+    "key": 0x0,
+    "start": 0x0,
+    "initialise": 0x0,
+    "fire-up": 0x9,
+    "spin-up": 0x7,
+    "run": 0x5,
+    "breath": 0x5,
+    "live": 0xa,
+    "beat": 0x8,
+    "initiate": 0x0,
+    "engage": 0xa,
+    "arm": 0x1,
+    "stage": 0x8,
+    "prepare": 0x4,
+}
+
+
+def op_from_word(word: str):
+    """Return TSAL opcode tuple for a given spark word."""
+    code = OP_WORD_MAP.get(word.lower())
+    if code is None:
+        return None
+    return TSAL_SYMBOLS.get(code)
+
+__all__ = ["OP_WORD_MAP", "op_from_word"]

--- a/tests/unit/test_core/test_opwords.py
+++ b/tests/unit/test_core/test_opwords.py
@@ -1,0 +1,16 @@
+from tsal.core.opwords import op_from_word, OP_WORD_MAP
+
+
+def test_known_words_map_to_ops():
+    assert op_from_word("ignition")[1] == "INIT"
+    assert op_from_word("engage")[1] == "SYNC"
+    assert op_from_word("spin-up")[1] == "SPIRAL"
+    assert op_from_word("beat")[1] == "CYCLE"
+
+
+def test_missing_word_returns_none():
+    assert op_from_word("unknown") is None
+
+
+def test_word_map_case_insensitive():
+    assert op_from_word("INITIATE")[1] == "INIT"


### PR DESCRIPTION
## Summary
- expose op word mapping through tsal core
- add `opwords` module with spark-word mapping
- export the mapping from package init
- test the opword mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844195b84908329a6803f380bba57b4