### PR TITLE
Add TSALExecutor with Meta Flag control

### DIFF
--- a/src/tsal/__init__.py
+++ b/src/tsal/__init__.py
@@ -15,6 +15,7 @@ from .core.spiral_vector import SpiralVector, phi_alignment
 from .core.spiral_fusion import SpiralFusionProtocol
 from .core.ethics_engine import EthicsEngine
 from .core.opwords import OP_WORD_MAP, op_from_word
+from .core.executor import MetaFlagProtocol, TSALExecutor
 from .renderer.code_render import mesh_to_python
 from .tristar.handshake import handshake as tristar_handshake
 from .utils.github_api import fetch_repo_files, fetch_languages
@@ -44,6 +45,8 @@ __all__ = [
     "phi_alignment",
     "OP_WORD_MAP",
     "op_from_word",
+    "MetaFlagProtocol",
+    "TSALExecutor",
     "fetch_repo_files",
     "fetch_languages",
     "mesh_to_python",

--- a/src/tsal/core/__init__.py
+++ b/src/tsal/core/__init__.py
@@ -18,6 +18,7 @@ from .optimizer_utils import (
 from .spiral_fusion import SpiralFusionProtocol
 from .state_vector import FourVector
 from .opwords import OP_WORD_MAP, op_from_word
+from .executor import MetaFlagProtocol, TSALExecutor
 
 __all__ = [
     "Rev_Eng",
@@ -36,4 +37,6 @@ __all__ = [
     "FourVector",
     "OP_WORD_MAP",
     "op_from_word",
+    "MetaFlagProtocol",
+    "TSALExecutor",
 ]

--- a/src/tsal/core/executor.py
+++ b/src/tsal/core/executor.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+"""Basic TSAL opcode executor with meta-flag control."""
+
+from dataclasses import dataclass, field
+from typing import List, Dict, Optional
+
+from .symbols import get_symbol
+from ..tristar.handshake import handshake
+from .rev_eng import Rev_Eng
+
+
+@dataclass
+class MetaFlagProtocol:
+    """Execution flags controlling TSALExecutor behaviour."""
+
+    dry_run: bool = False
+    narrative_mode: bool = False
+    resonance_threshold: float = 0.0
+    fork_tracking: bool = False
+
+
+class TSALExecutor:
+    """Execute TSAL opcodes with logging and optional dry-run."""
+
+    def __init__(self, meta: Optional[MetaFlagProtocol] = None, rev: Optional[Rev_Eng] = None) -> None:
+        self.meta = meta or MetaFlagProtocol()
+        self.rev = rev or Rev_Eng(origin="TSALExecutor")
+        self.state: Dict[str, float] = {}
+        self.op_log: List[int] = []
+        self.forks: List[int] = []
+
+    def execute(self, opcode: int, **kwargs) -> None:
+        symbol, name, desc = get_symbol(opcode)
+        if self.meta.narrative_mode:
+            self.rev.log_event("OP_NARRATIVE", opcode=opcode, name=name, desc=desc)
+        if opcode == 0xA:  # SYNC
+            local = kwargs.get("local", 0.0)
+            remote = kwargs.get("remote", 0.0)
+            metrics = handshake(local, remote, self.rev)
+            if metrics["resonance"] >= self.meta.resonance_threshold:
+                self.rev.log_event("RESONANCE_THRESHOLD", **metrics)
+        if self.meta.fork_tracking and kwargs.get("fork"):
+            fork_id = len(self.forks) + 1
+            self.forks.append(fork_id)
+            self.rev.log_event("FORK", id=fork_id, opcode=opcode)
+        if not self.meta.dry_run:
+            self.op_log.append(opcode)
+
+    def execute_sequence(self, ops: List[int]) -> None:
+        for op in ops:
+            self.execute(op)
+
+__all__ = ["MetaFlagProtocol", "TSALExecutor"]

--- a/tests/unit/test_core/test_executor.py
+++ b/tests/unit/test_core/test_executor.py
@@ -1,0 +1,27 @@
+from tsal.core.executor import TSALExecutor, MetaFlagProtocol
+from tsal.core.rev_eng import Rev_Eng
+
+
+def test_dry_run(monkeypatch):
+    rev = Rev_Eng(origin="unit")
+    events = []
+    monkeypatch.setattr(rev, "log_event", lambda action, **d: events.append((action, d)))
+    exe = TSALExecutor(MetaFlagProtocol(dry_run=True, narrative_mode=True), rev=rev)
+    exe.execute(0xA, local=0.1, remote=0.2, fork=True)
+    assert not exe.op_log
+    assert events and events[0][0] == "OP_NARRATIVE"
+
+
+def test_resonance_logging(monkeypatch):
+    rev = Rev_Eng(origin="unit")
+    events = []
+    monkeypatch.setattr(rev, "log_event", lambda action, **d: events.append((action, d)))
+    exe = TSALExecutor(MetaFlagProtocol(resonance_threshold=0.0), rev=rev)
+    exe.execute(0xA, local=0.5, remote=1.0)
+    assert any(a == "RESONANCE_THRESHOLD" for a, _ in events)
+
+
+def test_fork_tracking():
+    exe = TSALExecutor(MetaFlagProtocol(fork_tracking=True))
+    exe.execute(0x9, fork=True)
+    assert exe.forks == [1]


### PR DESCRIPTION
## Summary
- implement `TSALExecutor` with `MetaFlagProtocol`
- expose executor through package `__init__`
- test meta flag behaviours (dry run, resonance logging, fork tracking)

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684454a622688329a01c49fb020b2272