### PR TITLE
expand opcode word map

### DIFF
--- a/src/tsal/core/opwords.py
+++ b/src/tsal/core/opwords.py
@@ -3,21 +3,119 @@ from .symbols import TSAL_SYMBOLS
 
 # lowercase keyword -> hex opcode
 OP_WORD_MAP = {
+    # INIT
     "ignition": 0x0,
     "key": 0x0,
     "start": 0x0,
     "initialise": 0x0,
-    "fire-up": 0x9,
-    "spin-up": 0x7,
+    "ignite": 0x0,
+    "boot": 0x0,
+    "launch": 0x0,
+    "trigger": 0x0,
+    "begin": 0x0,
+    "commence": 0x0,
+    "initiate": 0x0,
+
+    # MESH
+    "arm": 0x1,
+    "connect": 0x1,
+    "link": 0x1,
+    "network": 0x1,
+    "bind": 0x1,
+    "join": 0x1,
+
+    # PHI
+    "phi": 0x2,
+    "transform": 0x2,
+    "harmonize": 0x2,
+    "balance": 0x2,
+
+    # ROT
+    "rotate": 0x3,
+    "pivot": 0x3,
+    "twist": 0x3,
+    "flip": 0x3,
+
+    # BOUND
+    "prepare": 0x4,
+    "limit": 0x4,
+    "restrict": 0x4,
+    "contain": 0x4,
+    "confine": 0x4,
+
+    # FLOW
     "run": 0x5,
     "breath": 0x5,
-    "live": 0xa,
+    "move": 0x5,
+    "stream": 0x5,
+    "pulse": 0x5,
+    "flow": 0x5,
+    "send": 0x5,
+
+    # SEEK
+    "search": 0x6,
+    "find": 0x6,
+    "locate": 0x6,
+    "discover": 0x6,
+
+    # SPIRAL
+    "spin-up": 0x7,
+    "evolve": 0x7,
+    "grow": 0x7,
+    "expand": 0x7,
+    "ascend": 0x7,
+
+    # CYCLE
     "beat": 0x8,
-    "initiate": 0x0,
-    "engage": 0xa,
-    "arm": 0x1,
     "stage": 0x8,
-    "prepare": 0x4,
+    "cycle": 0x8,
+    "loop": 0x8,
+    "repeat": 0x8,
+    "oscillate": 0x8,
+
+    # FORGE
+    "fire-up": 0x9,
+    "create": 0x9,
+    "forge": 0x9,
+    "build": 0x9,
+    "generate": 0x9,
+
+    # SYNC
+    "live": 0xA,
+    "engage": 0xA,
+    "synchronize": 0xA,
+    "align": 0xA,
+    "merge": 0xA,
+    "unify": 0xA,
+
+    # MASK
+    "mask": 0xB,
+    "hide": 0xB,
+    "cloak": 0xB,
+    "obscure": 0xB,
+
+    # CRYST
+    "crystallize": 0xC,
+    "solidify": 0xC,
+    "form": 0xC,
+    "shape": 0xC,
+
+    # SPEC
+    "analyze": 0xD,
+    "inspect": 0xD,
+    "scan": 0xD,
+    "survey": 0xD,
+
+    # BLOOM
+    "bloom": 0xE,
+    "blossom": 0xE,
+    "flower": 0xE,
+
+    # SAVE
+    "save": 0xF,
+    "store": 0xF,
+    "record": 0xF,
+    "preserve": 0xF,
 }
 
 
@@ -28,4 +126,16 @@ def op_from_word(word: str):
         return None
     return TSAL_SYMBOLS.get(code)
 
-__all__ = ["OP_WORD_MAP", "op_from_word"]
+
+def guess_opcode(word: str):
+    """Best-effort opcode lookup using close word matches."""
+    opcode = OP_WORD_MAP.get(word.lower())
+    if opcode is not None:
+        return TSAL_SYMBOLS.get(opcode)
+    from difflib import get_close_matches
+    matches = get_close_matches(word.lower(), OP_WORD_MAP.keys(), n=1)
+    if matches:
+        return TSAL_SYMBOLS.get(OP_WORD_MAP[matches[0]])
+    return None
+
+__all__ = ["OP_WORD_MAP", "op_from_word", "guess_opcode"]

--- a/tests/unit/test_core/test_opwords.py
+++ b/tests/unit/test_core/test_opwords.py
@@ -1,4 +1,4 @@
-from tsal.core.opwords import op_from_word, OP_WORD_MAP
+from tsal.core.opwords import op_from_word, guess_opcode, OP_WORD_MAP
 
 
 def test_known_words_map_to_ops():
@@ -8,9 +8,19 @@ def test_known_words_map_to_ops():
     assert op_from_word("beat")[1] == "CYCLE"
 
 
+def test_synonym_words_map_to_ops():
+    assert op_from_word("launch")[1] == "INIT"
+    assert op_from_word("connect")[1] == "MESH"
+    assert op_from_word("rotate")[1] == "ROT"
+
+
 def test_missing_word_returns_none():
     assert op_from_word("unknown") is None
 
 
 def test_word_map_case_insensitive():
     assert op_from_word("INITIATE")[1] == "INIT"
+
+
+def test_guess_opcode_close_match():
+    assert guess_opcode("launh")[1] == "INIT"


### PR DESCRIPTION
## Summary
- broaden `OP_WORD_MAP` with synonyms for all 16 opcodes
- add `guess_opcode` helper for fuzzy lookup
- cover new functionality in unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445b06ac7083298a8d9f76000cd976