### PR TITLE
Add connectivity and dynamic logic gate modules

### DIFF
--- a/src/tsal/core/__init__.py
+++ b/src/tsal/core/__init__.py
@@ -20,6 +20,8 @@ from .state_vector import FourVector
 from .opwords import OP_WORD_MAP, op_from_word
 from .spark_translator import SPARK_TO_OPCODE, translate_spark_word
 from .executor import MetaFlagProtocol, TSALExecutor
+from .connectivity import Node, verify_connectivity
+from .logic_gate import DynamicLogicGate
 
 __all__ = [
     "Rev_Eng",
@@ -42,4 +44,7 @@ __all__ = [
     "translate_spark_word",
     "MetaFlagProtocol",
     "TSALExecutor",
+    "Node",
+    "verify_connectivity",
+    "DynamicLogicGate",
 ]

--- a/src/tsal/core/connectivity.py
+++ b/src/tsal/core/connectivity.py
@@ -1,0 +1,34 @@
+"""Basic connectivity utilities for mesh nodes."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Iterable, Set
+
+
+class Node:
+    """Simple graph node."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.connections: Set[Node] = set()
+
+    def connect(self, other: "Node") -> None:
+        self.connections.add(other)
+        other.connections.add(self)
+
+
+def verify_connectivity(nodes: Iterable[Node]) -> bool:
+    """Return True if all nodes are reachable from the first node."""
+    node_list = list(nodes)
+    if not node_list:
+        return True
+    visited: Set[Node] = set()
+    q: deque[Node] = deque([node_list[0]])
+    while q:
+        n = q.popleft()
+        if n in visited:
+            continue
+        visited.add(n)
+        q.extend(n.connections - visited)
+    return len(visited) == len(node_list)

--- a/src/tsal/core/logic_gate.py
+++ b/src/tsal/core/logic_gate.py
@@ -1,0 +1,48 @@
+"""Dynamic logic gate with self-locking and plasticity."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+from tsal.utils.error_dignity import ERROR_DIR
+
+
+@dataclass
+class DynamicLogicGate:
+    """A simple adaptive logic gate."""
+
+    threshold_a: float = 0.5
+    threshold_b: float = 0.5
+    unlock_sequence: List[int] = field(default_factory=list)
+    history: List[int] = field(default_factory=list)
+    locked: bool = False
+
+    def process(self, value: float, reward: float = 0.0, simulate: bool = False) -> int:
+        """Process a value, optionally updating thresholds if not in simulate mode."""
+        try:
+            polarity = 1 if value >= 0 else -1
+            threshold = self.threshold_a if polarity > 0 else self.threshold_b
+            result = 1 if abs(value) >= threshold else 0
+            if not simulate and not self.locked:
+                if polarity > 0:
+                    self.threshold_a += reward * 0.1
+                else:
+                    self.threshold_b += reward * 0.1
+            self._check_sequence(result)
+            return result
+        except Exception as e:  # pragma: no cover - unexpected failures
+            ERROR_DIR.mkdir(exist_ok=True)
+            with open(ERROR_DIR / "logic_gate.log", "a") as f:
+                f.write(str(e) + "\n")
+            # treat error as lateral learning by relaxing thresholds
+            self.threshold_a *= 0.9
+            self.threshold_b *= 0.9
+            return 0
+
+    def _check_sequence(self, value: int) -> None:
+        self.history.append(value)
+        if len(self.unlock_sequence) <= len(self.history):
+            if self.history[-len(self.unlock_sequence) :] == self.unlock_sequence:
+                self.locked = not self.locked
+                self.history.clear()

--- a/tests/unit/test_core/test_connectivity.py
+++ b/tests/unit/test_core/test_connectivity.py
@@ -1,0 +1,20 @@
+from tsal.core import Node, verify_connectivity
+
+
+def test_verify_connectivity_true():
+    a = Node('a')
+    b = Node('b')
+    c = Node('c')
+    a.connect(b)
+    b.connect(c)
+    c.connect(a)
+    assert verify_connectivity([a, b, c]) is True
+
+
+def test_verify_connectivity_false():
+    a = Node('a')
+    b = Node('b')
+    c = Node('c')
+    a.connect(b)
+    # c is isolated
+    assert verify_connectivity([a, b, c]) is False

--- a/tests/unit/test_core/test_logic_gate.py
+++ b/tests/unit/test_core/test_logic_gate.py
@@ -1,0 +1,23 @@
+from tsal.core import DynamicLogicGate
+
+
+def test_logic_gate_lock_toggle():
+    gate = DynamicLogicGate(unlock_sequence=[1, 0])
+    assert gate.process(1) == 1
+    assert gate.locked is False
+    gate.process(0)
+    assert gate.locked is True
+    gate.process(1)
+    gate.process(0)
+    assert gate.locked is False
+
+
+def test_logic_gate_plasticity_and_simulation():
+    gate = DynamicLogicGate(threshold_a=1.0)
+    out1 = gate.process(0.5)
+    assert out1 == 0
+    gate.process(1.5, reward=1.0)
+    assert gate.threshold_a > 1.0
+    prev = gate.threshold_a
+    gate.process(1.5, reward=1.0, simulate=True)
+    assert gate.threshold_a == prev


### PR DESCRIPTION
## Summary
- provide `Node` and `verify_connectivity` utilities
- implement `DynamicLogicGate` for lockable logic processing
- export new helpers via `tsal.core`
- test connectivity and new logic gate behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446078962c83298663155214c9f812