### PR TITLE
Vectorized mesh sync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [ { name = "Samuel Edward Howells", email = "Samuel_Howells@hotmail.co
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.9"
-dependencies = ["requests", "pyyaml"]
+dependencies = ["requests", "pyyaml", "numpy"]
 
 [project.optional-dependencies]
 test = ["pytest"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 requests
 pyyaml
+numpy

--- a/tests/unit/test_core/test_phase_math.py
+++ b/tests/unit/test_core/test_phase_math.py
@@ -1,4 +1,6 @@
 from tsal.core.phase_math import phase_match_enhanced, mesh_phase_sync
+from tsal.core.phase_math import mesh_phase_sync_vectorized
+import pytest
 
 
 def test_phase_match_already_in_phase():
@@ -55,3 +57,16 @@ def test_mesh_phase_sync_empty_dict_with_verbose():
         "mesh_resonance": 0.0,
         "φ_signature": "φ^0.000_mesh",
     }
+
+
+def test_mesh_phase_sync_vectorized_matches_original():
+    nodes = {"x": 1.0, "y": 2.5, "z": -3.3}
+    legacy = mesh_phase_sync(nodes, 0.5)
+    vect = mesh_phase_sync_vectorized(nodes, 0.5)
+
+    assert vect["total_energy"] == pytest.approx(legacy["total_energy"])
+    assert set(vect["nodes"].keys()) == set(legacy["nodes"].keys())
+    for name in nodes:
+        assert vect["nodes"][name]["final"] == pytest.approx(
+            legacy["nodes"][name]["final"]
+        )


### PR DESCRIPTION
## Summary
- add vectorized mesh sync using NumPy
- include numpy in project deps
- test that vectorized code matches the original routine

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684460c02e108329acf17baad803dfeb