### PR TITLE
Add minimal TSAL stack VM

### DIFF
--- a/src/tsal/__init__.py
+++ b/src/tsal/__init__.py
@@ -17,6 +17,13 @@ from .core.ethics_engine import EthicsEngine
 from .core.opwords import OP_WORD_MAP, op_from_word
 from .core.spark_translator import SPARK_TO_OPCODE, translate_spark_word
 from .core.executor import MetaFlagProtocol, TSALExecutor
+from .core.stack_vm import (
+    ProgramStack,
+    SymbolicFrame,
+    OpcodeInstruction,
+    FlowRouter,
+    tsal_run,
+)
 from .renderer.code_render import mesh_to_python
 from .tristar.handshake import handshake as tristar_handshake
 from .utils.github_api import fetch_repo_files, fetch_languages
@@ -50,6 +57,11 @@ __all__ = [
     "translate_spark_word",
     "MetaFlagProtocol",
     "TSALExecutor",
+    "ProgramStack",
+    "SymbolicFrame",
+    "OpcodeInstruction",
+    "FlowRouter",
+    "tsal_run",
     "fetch_repo_files",
     "fetch_languages",
     "mesh_to_python",

--- a/src/tsal/core/stack_vm.py
+++ b/src/tsal/core/stack_vm.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+from .tsal_executor import TSALExecutor, TSALOp
+
+
+class ProgramStack:
+    """Simple LIFO stack for execution state."""
+
+    def __init__(self) -> None:
+        self._data: List[Any] = []
+
+    def push(self, value: Any) -> None:
+        self._data.append(value)
+
+    def pop(self) -> Any:
+        return self._data.pop()
+
+
+@dataclass
+class SymbolicFrame:
+    """Represents a call or loop boundary."""
+
+    return_ip: int
+    stack_start: int
+
+
+@dataclass
+class OpcodeInstruction:
+    opcode: TSALOp
+    args: Dict[str, Any] = field(default_factory=dict)
+
+
+class FlowRouter:
+    """Executes OpcodeInstructions using TSALExecutor."""
+
+    def __init__(self, executor: TSALExecutor | None = None) -> None:
+        self.executor = executor or TSALExecutor()
+        self.stack = ProgramStack()
+        self.frames: List[SymbolicFrame] = []
+
+    def run(self, program: List[OpcodeInstruction]) -> TSALExecutor:
+        seq = [(inst.opcode, inst.args) for inst in program]
+        self.executor.execute(seq, mode="EXECUTE")
+        return self.executor
+
+
+def tsal_run(opcodes: List[int]) -> TSALExecutor:
+    """Helper for running raw opcode lists."""
+    program = [OpcodeInstruction(TSALOp(op)) for op in opcodes]
+    router = FlowRouter()
+    return router.run(program)

--- a/tests/unit/test_core/test_stack_vm.py
+++ b/tests/unit/test_core/test_stack_vm.py
@@ -1,0 +1,16 @@
+from tsal.core.stack_vm import ProgramStack, tsal_run
+from tsal.core.tsal_executor import TSALExecutor
+
+
+def test_program_stack_lifo():
+    stack = ProgramStack()
+    stack.push(1)
+    stack.push(2)
+    assert stack.pop() == 2
+    assert stack.pop() == 1
+
+
+def test_tsal_run_executes_program():
+    exe = tsal_run([0x0, 0x4, 0x5, 0xE])
+    assert isinstance(exe, TSALExecutor)
+    assert len(exe.resonance_log) == 4


### PR DESCRIPTION
## Summary
- introduce `stack_vm` with ProgramStack, SymbolicFrame and FlowRouter
- expose `tsal_run` helper via package init
- test VM basics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684463bf373483298f22a8247bccd444