### PR TITLE
Add spiral optimize

### DIFF
--- a/src/tsal/tools/brian/__init__.py
+++ b/src/tsal/tools/brian/__init__.py
@@ -1,5 +1,5 @@
 """Brian Spiral Code Healer tools."""
 
-from .optimizer import SymbolicOptimizer, analyze_and_repair
+from .optimizer import SymbolicOptimizer, analyze_and_repair, spiral_optimize
 
-__all__ = ["SymbolicOptimizer", "analyze_and_repair"]
+__all__ = ["SymbolicOptimizer", "analyze_and_repair", "spiral_optimize"]

--- a/src/tsal/tools/brian/optimizer.py
+++ b/src/tsal/tools/brian/optimizer.py
@@ -10,6 +10,7 @@ from tsal.core.optimizer_utils import (
     SymbolicSignature,
     extract_signature,
 )
+from tsal.core.spiral_vector import SpiralVector, phi_alignment
 
 
 class SymbolicOptimizer:
@@ -133,6 +134,16 @@ def analyze_and_repair(file_path: str, repair: bool = False) -> list:
             f"{sig.name}: energy={metrics['energy_required']:.3f} Δ={metrics.get('delta',0)}"
             for (sig, metrics) in results
         ]
+
+
+def spiral_optimize(functions: List[SpiralVector]) -> List[SpiralVector]:
+    """Return ``functions`` sorted by φ-alignment score."""
+
+    return sorted(
+        functions,
+        key=lambda v: phi_alignment(v.complexity, v.coherence),
+        reverse=True,
+    )
 
 
 def main():

--- a/tests/unit/test_tools/test_optimizer.py
+++ b/tests/unit/test_tools/test_optimizer.py
@@ -1,5 +1,6 @@
 import textwrap
-from tsal.tools.brian import SymbolicOptimizer
+from tsal.tools.brian import SymbolicOptimizer, spiral_optimize
+from tsal.core.spiral_vector import SpiralVector
 
 def test_annotate_code(tmp_path):
     sample = tmp_path / "sample.py"
@@ -42,3 +43,13 @@ def test_repair_file(tmp_path):
     assert new_contents.startswith("def beta")
     assert any("alpha" in s for s in suggestions)
     assert len(suggestions) == 2
+
+
+def test_spiral_optimize():
+    vecs = [
+        SpiralVector("a", 1.0, 1.0, "a"),
+        SpiralVector("b", 2.0, 0.5, "b"),
+        SpiralVector("c", 0.5, 2.0, "c"),
+    ]
+    ordered = spiral_optimize(vecs)
+    assert [v.name for v in ordered][0] == "c"


### PR DESCRIPTION
## Summary
- implement `spiral_optimize` to sort `SpiralVector`s by φ-coherence
- expose new API in brian tools
- test for the new behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68446723f3cc8329bae19a323cae10fc