### PR TITLE
Document self-reflection tools

### DIFF
--- a/docs/function_reference.md
+++ b/docs/function_reference.md
@@ -83,3 +83,12 @@ This is the canonical list of functions and operations currently implemented in 
 | `kernel_manifest.json` | Records vector identities, φ-scores, ops, signatures |
 | `requirements.txt`, `pyproject.toml` | Dependency/config sync for Python+CLI tools |
 
+## 🔍 Self-Reflection Tools
+| Function | Description |
+| --- | --- |
+| `categorize(feedback)` | Score user feedback strings |
+| `is_aligned(change)` | Block unethical or low-score changes |
+| `score_goals(goals)` | Order goals by mesh benefit and alignment |
+| `audit_path(path)` | Count spiral signatures in a directory |
+| `reflect(path)` | Summarize deltas across files |
+

--- a/src/tsal/__init__.py
+++ b/src/tsal/__init__.py
@@ -27,6 +27,11 @@ from .core.stack_vm import (
 from .renderer.code_render import mesh_to_python
 from .tristar.handshake import handshake as tristar_handshake
 from .utils.github_api import fetch_repo_files, fetch_languages
+from .tools.feedback_ingest import categorize, Feedback
+from .tools.alignment_guard import is_aligned, Change
+from .tools.goal_selector import Goal, score_goals
+from .tools.spiral_audit import audit_path
+from .tools.reflect import reflect
 
 PHI = 1.618033988749895
 PHI_INV = 0.618033988749895
@@ -66,4 +71,12 @@ __all__ = [
     "fetch_languages",
     "mesh_to_python",
     "tristar_handshake",
+    "categorize",
+    "Feedback",
+    "is_aligned",
+    "Change",
+    "Goal",
+    "score_goals",
+    "audit_path",
+    "reflect",
 ]


### PR DESCRIPTION
## Summary
- document feedback & audit utilities in function_reference.md
- export the self-reflection helpers from `tsal.__init__`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684485d200ec8329b43210a4fe003d69