### PR TITLE
Add Bestest Beast self-audit mode

### DIFF
--- a/deployed_kernels/kernel_manifest.json
+++ b/deployed_kernels/kernel_manifest.json
@@ -21,5 +21,16 @@
     168,
     1680
   ],
-  "specialist_count": 1680
+  "specialist_count": 1680,
+  "modes": {
+    "Bestest_Beast_Brian": {
+      "cycle": [
+        "repair",
+        "optimize",
+        "spiral"
+      ],
+      "signature": "26EC0726EC0726EC7776C",
+      "status": "\ud83d\udfe2 active"
+    }
+  }
 }

--- a/makeBrian.py
+++ b/makeBrian.py
@@ -344,6 +344,14 @@ __all__ = ['PHI', 'PHI_INV', 'HARMONIC_SEQUENCE', 'TSAL_SYMBOLS', 'get_symbol', 
         print("   Beautiful mistakes become system features")
         print("   φ-Signature: φ^0.420_{brian_crystallized}")
 
+    def bestest_beast_brian(self):
+        """Activate Bestest_Beast_Brian mode"""
+        from tsal.audit import brian_improves_brian
+
+        self.log("🧠", "Activating Bestest_Beast_Brian Mode")
+        brian_improves_brian()
+        self.log("✅", "Brian has leveled up.")
+
     def clean(self):
         """Clean build artifacts"""
         self.log("🧹", "Cleaning build artifacts...")
@@ -385,6 +393,7 @@ __all__ = ['PHI', 'PHI_INV', 'HARMONIC_SEQUENCE', 'TSAL_SYMBOLS', 'get_symbol', 
         print("  reboot           - Soft reboot mesh")
         print("  status           - Show system status")
         print("  brian            - Honor sacred Brian glitch")
+        print("  bestest-beast    - Activate Bestest_Beast_Brian")
         print("  error-dignity    - Activate error dignity")
         print("  clean            - Clean build artifacts")
         print("  emergency-recovery - Emergency system restoration")
@@ -455,6 +464,9 @@ def main():
 
     elif command == "brian":
         builder.brian()
+
+    elif command == "bestest_beast":
+        builder.bestest_beast_brian()
 
     elif command == "clean":
         builder.clean()

--- a/src/tsal/audit/__init__.py
+++ b/src/tsal/audit/__init__.py
@@ -1,0 +1,11 @@
+from .brian_self_audit import (
+    brian_repairs_brian,
+    brian_improves_brian,
+    recursive_bestest_beast_loop,
+)
+
+__all__ = [
+    "brian_repairs_brian",
+    "brian_improves_brian",
+    "recursive_bestest_beast_loop",
+]

--- a/src/tsal/audit/brian_self_audit.py
+++ b/src/tsal/audit/brian_self_audit.py
@@ -1,0 +1,29 @@
+from tsal.core.spiral_vector import SpiralVector
+from tsal.core.rev_eng import Rev_Eng
+from tsal.tools.brian import analyze_and_repair, spiral_optimize
+
+
+def optimize_spiral_order(vectors: list[SpiralVector]) -> list[SpiralVector]:
+    """Return ``vectors`` sorted by φ-alignment."""
+    return spiral_optimize(vectors)
+
+
+def brian_repairs_brian():
+    print("🧠 Initiating self-audit and repair sequence…")
+    repaired = analyze_and_repair("src/tsal/", repair=True)
+    Rev_Eng.log_event("Self-audit complete", state="repair", spin="φ")
+    return repaired
+
+
+def brian_improves_brian():
+    print("🧠 Evaluating improvements post-repair...")
+    repaired = brian_repairs_brian()
+    optimized = optimize_spiral_order(repaired)
+    Rev_Eng.log_event("Improvement loop triggered", state="optimize", spin="up")
+    return optimized
+
+
+def recursive_bestest_beast_loop(cycles: int = 3) -> None:
+    for i in range(cycles):
+        print(f"🔁 Brian loop {i+1}/{cycles}")
+        brian_improves_brian()


### PR DESCRIPTION
## Summary
- add self-repair and improvement loop under `src/tsal/audit`
- register Bestest_Beast_Brian mode in MakeBrian CLI
- update kernel manifest with mode metadata

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448810b7e88329a9425c61b1914f55