### PR TITLE
Fix bestest beast CLI loop

### DIFF
--- a/src/tsal/audit/brian_self_audit.py
+++ b/src/tsal/audit/brian_self_audit.py
@@ -1,6 +1,9 @@
+from pathlib import Path
 from tsal.core.spiral_vector import SpiralVector
 from tsal.core.rev_eng import Rev_Eng
 from tsal.tools.brian import analyze_and_repair, spiral_optimize
+
+rev = Rev_Eng(origin="self_audit")
 
 
 def optimize_spiral_order(vectors: list[SpiralVector]) -> list[SpiralVector]:
@@ -8,22 +11,39 @@ def optimize_spiral_order(vectors: list[SpiralVector]) -> list[SpiralVector]:
     return spiral_optimize(vectors)
 
 
-def brian_repairs_brian():
+
+def brian_repairs_brian() -> list[str]:
+    """Run ``analyze_and_repair`` on every Python file in ``src/tsal``."""
+
     print("🧠 Initiating self-audit and repair sequence…")
-    repaired = analyze_and_repair("src/tsal/", repair=True)
-    Rev_Eng.log_event("Self-audit complete", state="repair", spin="φ")
+    repaired: list[str] = []
+    for file in Path("src/tsal").rglob("*.py"):
+        repaired.extend(analyze_and_repair(str(file), repair=True))
+    rev.log_event("Self-audit complete", state="repair", spin="φ")
     return repaired
 
 
-def brian_improves_brian():
+def brian_improves_brian() -> list[str]:
+    """Run repair cycle and log the event."""
+
     print("🧠 Evaluating improvements post-repair...")
-    repaired = brian_repairs_brian()
-    optimized = optimize_spiral_order(repaired)
-    Rev_Eng.log_event("Improvement loop triggered", state="optimize", spin="up")
-    return optimized
+    suggestions = brian_repairs_brian()
+    rev.log_event("Improvement loop triggered", state="optimize", spin="up")
+    return suggestions
+
+
+import sys
 
 
 def recursive_bestest_beast_loop(cycles: int = 3) -> None:
+    """Repeat ``brian_improves_brian`` ``cycles`` times."""
+
+    if len(sys.argv) > 1:
+        try:
+            cycles = int(sys.argv[1])
+        except ValueError:
+            pass
+
     for i in range(cycles):
         print(f"🔁 Brian loop {i+1}/{cycles}")
         brian_improves_brian()


### PR DESCRIPTION
## Summary
- self audit CLI now walks all src/tsal python files
- log events using a Rev_Eng instance
- honour CLI cycle arg when invoking `tsal-bestest-beast`

## Testing
- `pytest -q`
- `tsal-bestest-beast 1`

------
https://chatgpt.com/codex/tasks/task_e_684493f1d8dc8329a08cbba72fac81de