### PR TITLE
Self-audit loop tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ tsal-bestest-beast 3 src/tsal --safe
 tsal-meshkeeper --render
 ```
 
+### How to run Bestest Beast
+
+```
+tsal-bestest-beast 5 --safe
+tsal-bestest-beast 9
+```
+
 ## GitHub Language Database
 
 You can fetch the list of programming languages used on GitHub with:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,13 @@
+# CLI usage
+
+Run in safe mode:
+
+```bash
+tsal-bestest-beast 5 --safe
+```
+
+Full run:
+
+```bash
+tsal-bestest-beast 9
+```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    selfaudit: internal self-audit tests

--- a/src/tsal/audit/brian_self_audit.py
+++ b/src/tsal/audit/brian_self_audit.py
@@ -62,10 +62,22 @@ def brian_improves_brian(base: Path | str = Path("src/tsal"), safe: bool = False
         rev.log_event("Improvement loop triggered", state="optimize", spin="up")
         return optimized
 
-def recursive_bestest_beast_loop(cycles: int = 3, base: Path | str = Path("src/tsal"), safe: bool = False) -> None:
+def recursive_bestest_beast_loop(
+    cycles: int = 3, base: Path | str = Path("src/tsal"), safe: bool = False
+) -> None:
+    repaired_total = 0
+    skipped_total = 0
+    flagged_total = 0
     for i in range(cycles):
         print(f"🔁 Brian loop {i+1}/{cycles}")
-        brian_improves_brian(base=base, safe=safe)
+        results = brian_repairs_brian(base=base, safe=safe)
+        flagged = [r for r in results if isinstance(r, str) and r.startswith("ANTISPIRAL")]
+        flagged_total += len(flagged)
+        if safe:
+            skipped_total += len(results) - len(flagged)
+        else:
+            repaired_total += len(results) - len(flagged)
+    print(f"Summary → repaired={repaired_total} skipped={skipped_total} flagged={flagged_total}")
 
 def cli_main() -> None:
     parser = argparse.ArgumentParser(description="Run Bestest Beast Brian loop")

--- a/src/tsal/core/spiral_vector.py
+++ b/src/tsal/core/spiral_vector.py
@@ -37,3 +37,6 @@ class SpiralVector:
     def alignment(self) -> float:
         """Return the φ-alignment score for this vector."""
         return phi_alignment(self.complexity, self.coherence)
+
+
+__all__ = ["SpiralVector", "phi_alignment"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytestmark = pytest.mark.selfaudit

--- a/tests/test_audit_safemode.py
+++ b/tests/test_audit_safemode.py
@@ -1,6 +1,20 @@
+import pytest
 from tsal.audit.brian_self_audit import recursive_bestest_beast_loop
+from tsal.tools.brian import analyze_and_repair
+
+pytestmark = pytest.mark.selfaudit
 
 
-def test_safe_mode(tmp_path):
-    (tmp_path / "a.py").write_text("def a():\n    pass\n")
-    recursive_bestest_beast_loop(1, safe=True)
+def test_safe_mode_skips_writes(tmp_path):
+    sample = tmp_path / "a.py"
+    original = "def a():\n    pass\n"
+    sample.write_text(original)
+    recursive_bestest_beast_loop(1, base=tmp_path, safe=True)
+    assert sample.read_text() == original
+
+
+def test_unrepairable_tagged_antispiral(tmp_path):
+    bad = tmp_path / "bad.py"
+    bad.write_text("def a(:\n    pass")
+    res = analyze_and_repair(bad)
+    assert any("ANTISPIRAL" in r for r in res)


### PR DESCRIPTION
## Summary
- print run summary in `recursive_bestest_beast_loop`
- flag SyntaxError files as `ANTISPIRAL`
- document CLI usage
- add safe-mode and unrepairable tests
- mark tests with `selfaudit`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a59411e883298b76d9ae2d4a2a17