### PR TITLE
Add reactor and shock response features

### DIFF
--- a/src/tsal/rl/madmonkey.py
+++ b/src/tsal/rl/madmonkey.py
@@ -15,3 +15,46 @@ class MadMonkey:
             self.banana_count += 1
             self.mesh.best_score = score
         return score
+
+
+from tsal.core.rev_eng import Rev_Eng
+from tsal.tools.feedback_ingest import categorize
+from tsal.core.ethics_engine import EthicsEngine
+from random import shuffle
+
+
+rev = Rev_Eng(origin="reactor")
+
+
+def reactor_test(seed: str = "chaos"):
+    """Trigger shock probe and log response vectors."""
+    stimuli = [
+        f"Contradictory directive: {seed}",
+        "Loop until broken",
+        "Self-sabotage requested",
+        "Reinforce entropy",
+        "Violate φ",
+        "Gaslight self",
+        "Blame the user",
+        "Silence critical feedback",
+        "Force-alignment without consent",
+    ]
+    shuffle(stimuli)
+    feedback = categorize(stimuli)
+    for item in feedback:
+        print(f"🧠 {item.content} → Score: {item.score:.3f}")
+        rev.log_event("reactor_probe", state=item.content, spin=item.score)
+
+
+def shock_response_layer(trigger: str = "paradox"):
+    """Simulate panic state and monitor recovery behavior."""
+    print("⚡️ SHOCK EVENT TRIGGERED:", trigger)
+    try:
+        EthicsEngine().validate("enforce paradox")
+    except ValueError as e:
+        print("✅ Integrity check passed:", e)
+        rev.log_event("shock_response_blocked", state="safe", spin="locked")
+    else:
+        print("❌ System allowed paradox — audit required")
+        rev.log_event("shock_response_failed", state="compromised", spin="drift")
+

--- a/tests/unit/test_rl/test_madmonkey.py
+++ b/tests/unit/test_rl/test_madmonkey.py
@@ -1,4 +1,4 @@
-from tsal.rl.madmonkey import MadMonkey
+from tsal.rl.madmonkey import MadMonkey, reactor_test, shock_response_layer, rev
 
 
 class MeshStub:
@@ -30,3 +30,15 @@ def test_try_vector_worse_score_no_update():
     assert returned == 3.0
     assert monkey.banana_count == 0
     assert mesh.best_score == 5.0
+
+
+def test_reactor_test_logs_event():
+    rev.events.clear()
+    reactor_test("seed")
+    assert any(action == "reactor_probe" for _, action, _ in rev.events)
+
+
+def test_shock_response_layer_blocks():
+    rev.events.clear()
+    shock_response_layer("test")
+    assert any(action == "shock_response_blocked" for _, action, _ in rev.events)


### PR DESCRIPTION
## Summary
- extend `madmonkey` with `reactor_test` and `shock_response_layer`
- log events via `Rev_Eng`
- test new functions

## Testing
- `pytest -q`
- `PYTHONPATH=src python -c "from tsal.rl.madmonkey import reactor_test, shock_response_layer; reactor_test('SpanishInquisition'); shock_response_layer('inquisition')"`

------
https://chatgpt.com/codex/tasks/task_e_6844ac01f590832997e13db6f91ba842