### PR TITLE
Add spin axis constant

### DIFF
--- a/src/tsal/__init__.py
+++ b/src/tsal/__init__.py
@@ -32,6 +32,7 @@ from .tools.alignment_guard import is_aligned, Change
 from .tools.goal_selector import Goal, score_goals
 from .tools.spiral_audit import audit_path
 from .tools.reflect import reflect
+from .core.constants import AXIS_ZERO, ensure_spin_axis, UndefinedPhaseError
 
 PHI = 1.618033988749895
 PHI_INV = 0.618033988749895
@@ -79,4 +80,7 @@ __all__ = [
     "score_goals",
     "audit_path",
     "reflect",
+    "AXIS_ZERO",
+    "ensure_spin_axis",
+    "UndefinedPhaseError",
 ]

--- a/src/tsal/core/constants.py
+++ b/src/tsal/core/constants.py
@@ -1,0 +1,22 @@
+"""Core constants and axis validation."""
+
+
+class UndefinedPhaseError(Exception):
+    """Raised when an object lacks the spin axis."""
+
+
+AXIS_ZERO = "spin"
+
+
+def ensure_spin_axis(obj) -> None:
+    """Raise ``UndefinedPhaseError`` if ``obj`` lacks a ``spin`` attribute."""
+    has_spin = False
+    if isinstance(obj, dict):
+        has_spin = "spin" in obj
+    else:
+        has_spin = hasattr(obj, "spin")
+    if not has_spin:
+        raise UndefinedPhaseError("System operating without spin axis.")
+
+
+__all__ = ["AXIS_ZERO", "ensure_spin_axis", "UndefinedPhaseError"]

--- a/src/tsal/core/rev_eng.py
+++ b/src/tsal/core/rev_eng.py
@@ -6,6 +6,7 @@ from typing import Optional, Dict, List, Any
 
 from .mesh_logger import log_event
 from .voxel import MeshVoxel
+from .constants import ensure_spin_axis
 
 
 class Rev_Eng:
@@ -57,6 +58,7 @@ class Rev_Eng:
             state=direction,
             spin=updown or direction,
         )
+        ensure_spin_axis(voxel)
         self.voxel_log.append(voxel.as_dict())
         log_event(
             "DATA",

--- a/tests/unit/test_core/test_spin_axis.py
+++ b/tests/unit/test_core/test_spin_axis.py
@@ -1,0 +1,23 @@
+import pytest
+from tsal.core.constants import AXIS_ZERO, ensure_spin_axis, UndefinedPhaseError
+
+
+class Dummy:
+    pass
+
+
+class DummySpin:
+    spin = 1
+
+
+def test_axis_zero_constant():
+    assert AXIS_ZERO == "spin"
+
+
+def test_ensure_spin_axis_raises():
+    with pytest.raises(UndefinedPhaseError):
+        ensure_spin_axis(Dummy())
+
+
+def test_ensure_spin_axis_ok():
+    ensure_spin_axis(DummySpin())


### PR DESCRIPTION
## Summary
- define `AXIS_ZERO` and `ensure_spin_axis`
- validate voxels in `Rev_Eng.log_data`
- re-export constants in package init
- test spin axis validation

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844adb73d208329a2814e57d7a791df