### PR TITLE
Add missing docs for self-reflection tools

### DIFF
--- a/docs/Brian_SelfReflection_Design.md
+++ b/docs/Brian_SelfReflection_Design.md
@@ -10,3 +10,4 @@ This document sketches the modules that let Brian observe and repair itself.
 - `memory/core_brian_manifest.md` records Brian's purpose and history.
 
 Run `tsal-spiral-audit` or `tsal-reflect` to exercise these tools from the CLI.
+They require the `tsal` package to be installed with Matplotlib available.


### PR DESCRIPTION
## Summary
- document that new CLI utilities require `tsal` and matplotlib

## Testing
- `pip install -e .` *(fails: ImportError: cannot import name '_api' from partially initialized module 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_6844b9b4855c832997acaa045fa42dae