### PR TITLE
Add more VSCode commands

### DIFF
--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -1,13 +1,30 @@
 const vscode = require('vscode');
 const cp = require('child_process');
 
+function runInTerminal(command) {
+    const terminal = vscode.window.createTerminal('Brian Spiral');
+    terminal.show();
+    terminal.sendText(command);
+}
+
 function activate(context) {
-    let runAudit = vscode.commands.registerCommand('brian.runSelfAudit', () => {
-        const terminal = vscode.window.createTerminal('Brian Spiral');
-        terminal.show();
-        terminal.sendText('brian audit --self');
-    });
-    context.subscriptions.push(runAudit);
+    const commands = [
+        ['brian.runSelfAudit', () => runInTerminal('brian audit --self')],
+        ['brian.runBestestBeast', () => runInTerminal('tsal-bestest-beast 3')],
+        ['brian.optimizeCurrentFile', () => {
+            const file = vscode.window.activeTextEditor?.document.fileName;
+            if (file) runInTerminal(`brian-optimize ${file}`);
+        }],
+        ['brian.logMeshVectors', () => {
+            const file = vscode.window.activeTextEditor?.document.fileName;
+            if (file) runInTerminal(`tsal-reflect --origin ${file}`);
+        }],
+    ];
+
+    for (const [name, callback] of commands) {
+        const disposable = vscode.commands.registerCommand(name, callback);
+        context.subscriptions.push(disposable);
+    }
 }
 
 exports.activate = activate;

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -5,11 +5,19 @@
   "version": "0.1.0",
   "publisher": "bikersam",
   "engines": { "vscode": "^1.85.0" },
-  "activationEvents": ["onCommand:brian.runSelfAudit"],
+  "activationEvents": [
+    "onCommand:brian.runSelfAudit",
+    "onCommand:brian.runBestestBeast",
+    "onCommand:brian.optimizeCurrentFile",
+    "onCommand:brian.logMeshVectors"
+  ],
   "main": "./extension.js",
   "contributes": {
     "commands": [
-      { "command": "brian.runSelfAudit", "title": "\ud83e\udde0 Brian: Run Self-Audit Spiral" }
+      { "command": "brian.runSelfAudit", "title": "\ud83e\udde0 Brian: Run Self-Audit Spiral" },
+      { "command": "brian.runBestestBeast", "title": "\ud83d\udc1d Brian: Full Audit" },
+      { "command": "brian.optimizeCurrentFile", "title": "\ud83d\udd27 Brian: Optimize Current File" },
+      { "command": "brian.logMeshVectors", "title": "\ud83d\udd0d Brian: Log Mesh Vectors" }
     ]
   },
   "scripts": { "compile": "tsc -p ." },


### PR DESCRIPTION
## Summary
- expand the VSCode extension to run audit, bestest-beast, optimizer and vector logging

## Testing
- `pytest -q` *(fails: 39 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6844cd413f808329bbf33ac12206c866