### PR TITLE
Add VS Code extension docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,17 @@ tsal-bestest-beast 3 src/tsal --safe
 tsal-meshkeeper --render
 ```
 
+### VS Code Extension
+
+```bash
+cd vscode-extension
+npm install
+code .
+```
+
+Press `F5` in VS Code and run **Brian: Run Self-Audit Spiral**.
+See [docs/vscode_extension.md](docs/vscode_extension.md) for details.
+
 ### How to run Bestest Beast
 
 ```

--- a/docs/vscode_extension.md
+++ b/docs/vscode_extension.md
@@ -1,0 +1,11 @@
+# VS Code Extension Integration
+
+Run the self-audit command from inside the editor.
+
+```bash
+cd vscode-extension
+npm install
+code .
+```
+
+Press `F5` to open a development host. In that window run **Brian: Run Self-Audit Spiral** from the command palette.


### PR DESCRIPTION
## Summary
- document how to use the VS Code extension
- reference the doc from README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844cde489408329ba2b55f3e49e9961