### PR TITLE
Add VS Code extension README

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,0 +1,7 @@
+# Brian VS Code Extension
+
+## 🧠 1. VSCode Extension Integration
+
+| Action | Command | Description |
+| --- | --- | --- |
+| **Live symbolic alignment check** | `tsal-reflect --origin filename.py` | Dump symbolic vector map |


### PR DESCRIPTION
## Summary
- document VS Code extension usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6844cdf8ffc08329bda808997b7242e2