### PR TITLE
Add VSCode extension snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ For a direct repair:
 See [USAGE.md](USAGE.md) for a minimal CLI rundown.
 Flowchart: [docs/SPIRAL_GUIDE.md](docs/SPIRAL_GUIDE.md).
 
+## VSCode Extension
+For instant bug fixes, install the built-in extension and run:
+`brian-optimize filename.py` – this triggers Rev_Eng + repair.
+See [docs/vscode_extension_integration.md](docs/vscode_extension_integration.md) for details.
+
 ### TriStar Handshake Example
 ```python
 from tsal.tristar import handshake

--- a/docs/vscode_extension_integration.md
+++ b/docs/vscode_extension_integration.md
@@ -1,0 +1,5 @@
+# VSCode Extension Integration
+
+| Feature               | Command                       | Notes                |
+|-----------------------|-------------------------------|----------------------|
+| Instant bug diagnosis | `brian-optimize filename.py`  | Calls Rev_Eng + repair |


### PR DESCRIPTION
## Summary
- add a VSCode extension section in README
- create a short doc describing the instant bug diagnosis command

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6844ce0ff9608329a43608aa195de12d