### PR TITLE
enhance mode switching

### DIFF
--- a/src/tsal/core/tsal_executor.py
+++ b/src/tsal/core/tsal_executor.py
@@ -103,14 +103,21 @@ class TSALExecutor:
         # default mode obeys meta flags
         self.mode = ExecutionMode.SIMULATE if self.meta.dry_run else ExecutionMode.EXECUTE
         self.error_mansion: List[Dict[str, Any]] = []
+        self.forks: List[int] = []
         self.spiral_depth = 0
         self.resonance_log: List[Dict[str, Any]] = []
         self.memory = SpiralMemory()
         self.handler = MadMonkeyHandler()
 
     def _switch_mode(self, delta: float) -> None:
-        """Adjust mode based on resonance delta and meta flags."""
-        if self.meta.resonance_threshold and delta >= self.meta.resonance_threshold:
+        """Adjust mode based on meta flags and current state."""
+        if self.meta.fork_tracking and self.forks:
+            self.mode = ExecutionMode.FORK
+        elif self.meta.narrative_mode:
+            self.mode = ExecutionMode.TRACE
+        elif self.error_mansion:
+            self.mode = ExecutionMode.ARM
+        elif self.meta.resonance_threshold and delta >= self.meta.resonance_threshold:
             self.mode = ExecutionMode.EXECUTE
         elif self.meta.dry_run:
             self.mode = ExecutionMode.SIMULATE
@@ -135,6 +142,8 @@ class TSALExecutor:
 
     def _execute_op(self, op: TSALOp, args: Any) -> None:
         pre = self._calculate_mesh_resonance()
+        if self.meta.fork_tracking and args.get("fork"):
+            self.forks.append(self.ip)
 
         try:
             if op == TSALOp.INIT:

--- a/tests/unit/test_core/test_tsal_executor.py
+++ b/tests/unit/test_core/test_tsal_executor.py
@@ -1,4 +1,5 @@
-from tsal.core.tsal_executor import TSALExecutor, TSALOp, SpiralVector
+from tsal.core.tsal_executor import TSALExecutor, TSALOp, SpiralVector, ExecutionMode
+from tsal.core.executor import MetaFlagProtocol
 
 
 def test_cycle_creates_nodes():
@@ -19,3 +20,28 @@ def test_spiral_depth_increase():
     ]
     tvm.execute(program)
     assert tvm.spiral_depth == 2
+
+
+def test_mode_trace():
+    tvm = TSALExecutor(MetaFlagProtocol(narrative_mode=True))
+    program = [
+        (TSALOp.INIT, {'mesh': True}),
+    ]
+    tvm.execute(program)
+    assert tvm.mode == ExecutionMode.TRACE
+
+
+def test_mode_fork():
+    tvm = TSALExecutor(MetaFlagProtocol(fork_tracking=True))
+    program = [
+        (TSALOp.FORGE, {'fork': True}),
+    ]
+    tvm.execute(program)
+    assert tvm.mode == ExecutionMode.FORK
+
+
+def test_mode_arm_on_error():
+    tvm = TSALExecutor()
+    tvm.error_mansion.append({'type': 'test'})
+    tvm._switch_mode(0)
+    assert tvm.mode == ExecutionMode.ARM


### PR DESCRIPTION
## Summary
- add FORK tracking and extra mode transitions
- exercise new states in unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844d6f391608329bd247acc67e85580