### PR TITLE
Add multi-language signature extraction and CLI wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ tsal-spiral-audit path/to/code
 tsal-reflect --origin demo
 tsal-bestest-beast 3 src/tsal --safe
 tsal-meshkeeper --render
+tsal-meshkeeper --dump mesh.json
 ```
 
 Example output:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ dependencies = [
   "requests",
   "numpy",
   "matplotlib",
-  "pyyaml"
+  "pyyaml",
+  "esprima",
 ]
 requires-python = ">=3.9"
 
@@ -24,6 +25,8 @@ test = ["pytest"]
 brian = "tsal.cli.brian:main"
 tsal-bestest-beast = "tsal.cli.beast:main"
 tsal-reflect = "tsal.cli.reflect:main"
+tsal-meshkeeper = "tsal.cli.meshkeeper:main"
+tsal-spiral-audit = "tsal.tools.spiral_audit:main"
 
 [tool.setuptools.packages.find]
 where = ["src", "tools"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 pyyaml
 numpy
 matplotlib
+esprima

--- a/src/tsal/cli/__init__.py
+++ b/src/tsal/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Small CLI wrappers."""

--- a/src/tsal/cli/beast.py
+++ b/src/tsal/cli/beast.py
@@ -1,0 +1,4 @@
+from tsal.audit.brian_self_audit import cli_main as main
+
+if __name__ == "__main__":
+    main()

--- a/src/tsal/cli/brian.py
+++ b/src/tsal/cli/brian.py
@@ -1,0 +1,4 @@
+from tsal.tools.brian.optimizer import main
+
+if __name__ == "__main__":
+    main()

--- a/src/tsal/cli/meshkeeper.py
+++ b/src/tsal/cli/meshkeeper.py
@@ -1,0 +1,4 @@
+from tsal.tools.meshkeeper import main
+
+if __name__ == "__main__":
+    main()

--- a/src/tsal/cli/reflect.py
+++ b/src/tsal/cli/reflect.py
@@ -1,0 +1,4 @@
+from tsal.tools.reflect import main
+
+if __name__ == "__main__":
+    main()

--- a/src/tsal/core/optimizer_utils.py
+++ b/src/tsal/core/optimizer_utils.py
@@ -1,5 +1,5 @@
 import ast
-from typing import List
+from typing import Any, List
 
 
 class SymbolicSignature:
@@ -26,4 +26,48 @@ def extract_signature(node: ast.AST, name: str) -> SymbolicSignature:
     return SymbolicSignature(name=name, vector=vector)
 
 
-__all__ = ["SymbolicSignature", "node_complexity", "extract_signature"]
+def _walk_js(obj: Any):
+    if isinstance(obj, dict):
+        yield obj
+        for v in obj.values():
+            if isinstance(v, (dict, list)):
+                yield from _walk_js(v)
+    elif isinstance(obj, list):
+        for item in obj:
+            yield from _walk_js(item)
+
+
+def extract_signature_from_source(
+    source: str, name: str, language: str = "python"
+) -> SymbolicSignature:
+    """Return signature from source code for ``language``."""
+    if language == "python":
+        tree = ast.parse(source)
+        return extract_signature(tree, name)
+    if language == "javascript":
+        import esprima
+
+        tree = esprima.parseScript(source).toDict()
+        nodes = list(_walk_js(tree))
+        complexity = len(nodes)
+        branches = len(
+            [n for n in nodes if n.get("type") in {"IfStatement", "SwitchStatement"}]
+        )
+        loops = len(
+            [
+                n
+                for n in nodes
+                if n.get("type") in {"ForStatement", "WhileStatement", "DoWhileStatement"}
+            ]
+        )
+        vector = [complexity, branches, loops]
+        return SymbolicSignature(name=name, vector=vector)
+    raise ValueError(f"Unsupported language: {language}")
+
+
+__all__ = [
+    "SymbolicSignature",
+    "node_complexity",
+    "extract_signature",
+    "extract_signature_from_source",
+]

--- a/src/tsal/tools/meshkeeper.py
+++ b/src/tsal/tools/meshkeeper.py
@@ -68,8 +68,12 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="TSAL Meshkeeper")
     parser.add_argument("log", nargs="?", default="data/mesh_log.jsonl")
     parser.add_argument("--render", action="store_true")
+    parser.add_argument("--dump", metavar="PATH", help="write raw voxels to file")
     args = parser.parse_args()
     voxels = scan(args.log)
+    if args.dump:
+        Path(args.dump).write_text(json.dumps(voxels))
+        return
     if args.render:
         render_voxels(voxels)
     else:

--- a/tests/unit/test_core/test_optimizer_utils.py
+++ b/tests/unit/test_core/test_optimizer_utils.py
@@ -1,0 +1,13 @@
+from tsal.core.optimizer_utils import extract_signature_from_source
+
+
+def test_extract_signature_python():
+    code = "def foo(x):\n    if x:\n        return 1\n    return 0\n"
+    sig = extract_signature_from_source(code, "foo")
+    assert sig.vector[0] > 0
+
+
+def test_extract_signature_javascript():
+    js = "function foo(x){ if(x){ return 1; } return 0; }"
+    sig = extract_signature_from_source(js, "foo", language="javascript")
+    assert sig.vector[0] > 0


### PR DESCRIPTION
## Summary
- support JavaScript source in `extract_signature_from_source`
- wrap CLI tools under `tsal.cli`
- expose `tsal-meshkeeper` and `tsal-spiral-audit` in package
- add `--dump` option to `meshkeeper`
- test new signature helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f84118748329af354e3b8071880d