### PR TITLE
Add module template generator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ tsal-bestest-beast = "tsal.cli.beast:main"
 tsal-reflect = "tsal.cli.reflect:main"
 tsal-meshkeeper = "tsal.cli.meshkeeper:main"
 tsal-spiral-audit = "tsal.tools.spiral_audit:main"
+tsal-module-draft = "tsal.tools.module_draft:main"
 
 [tool.setuptools.packages.find]
 where = ["src", "tools"]

--- a/src/tsal/tools/__init__.py
+++ b/src/tsal/tools/__init__.py
@@ -8,6 +8,7 @@ from .goal_selector import Goal, score_goals
 from .spiral_audit import audit_path
 from .reflect import reflect
 from .kintsugi.kintsugi import kintsugi_repair
+from .module_draft import generate_template, draft_directory
 
 __all__ = [
     "real_time_codec",
@@ -25,4 +26,6 @@ __all__ = [
     "audit_path",
     "reflect",
     "kintsugi_repair",
+    "generate_template",
+    "draft_directory",
 ]

--- a/src/tsal/tools/module_draft.py
+++ b/src/tsal/tools/module_draft.py
@@ -1,0 +1,53 @@
+import ast
+from pathlib import Path
+from typing import List
+
+
+def generate_template(file_path: str) -> str:
+    """Return a stripped template of ``file_path`` preserving public interface."""
+    path = Path(file_path)
+    tree = ast.parse(path.read_text())
+
+    new_body: List[ast.stmt] = []
+    body = list(tree.body)
+
+    if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant) and isinstance(body[0].value.value, str):
+        new_body.append(body.pop(0))
+
+    for node in body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            new_body.append(node)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            node.body = [ast.Pass()]
+            new_body.append(node)
+
+    tree.body = new_body
+    return ast.unparse(tree)
+
+
+def draft_directory(base: Path, dest: Path) -> List[Path]:
+    """Generate templates for ``base`` under ``dest`` directory."""
+    generated = []
+    for file in base.rglob("*.py"):
+        template = generate_template(str(file))
+        target = dest / file.relative_to(base)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(template)
+        generated.append(target)
+    return generated
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate interface templates")
+    parser.add_argument("base", nargs="?", default="src/tsal")
+    parser.add_argument("--dest", default="drafts")
+    args = parser.parse_args()
+
+    paths = draft_directory(Path(args.base), Path(args.dest))
+    print(f"Generated {len(paths)} templates under {args.dest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_tools/test_module_draft.py
+++ b/tests/unit/test_tools/test_module_draft.py
@@ -1,0 +1,22 @@
+from tsal.tools.module_draft import generate_template
+import textwrap
+
+
+def test_generate_template(tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text(textwrap.dedent(
+        """
+        import os
+
+        def foo(x):
+            return x + 1
+
+        class Bar:
+            def baz(self):
+                return 2
+        """
+    ))
+    template = generate_template(sample)
+    assert "def foo" in template
+    assert "class Bar" in template
+    assert template.count("pass") == 2


### PR DESCRIPTION
## Summary
- add tool `module_draft` to create stripped templates of modules
- export `generate_template` and `draft_directory`
- expose command `tsal-module-draft` in packaging
- test template generation

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684551877e5883299a836588075cbc55