### PR TITLE
Add repair watchdog

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ tsal-reflect --origin demo
 tsal-bestest-beast 3 src/tsal --safe
 tsal-meshkeeper --render
 tsal-meshkeeper --dump mesh.json
+tsal-watchdog src/tsal --repair --interval 5
 ```
 
 Example output:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ tsal-reflect = "tsal.cli.reflect:main"
 tsal-meshkeeper = "tsal.cli.meshkeeper:main"
 tsal-spiral-audit = "tsal.tools.spiral_audit:main"
 tsal-module-draft = "tsal.tools.module_draft:main"
+tsal-watchdog = "tsal.cli.watchdog:main"
 
 [tool.setuptools.packages.find]
 where = ["src", "tools"]

--- a/src/tsal/cli/watchdog.py
+++ b/src/tsal/cli/watchdog.py
@@ -1,0 +1,4 @@
+from tsal.tools.watchdog import main
+
+if __name__ == "__main__":
+    main()

--- a/src/tsal/tools/__init__.py
+++ b/src/tsal/tools/__init__.py
@@ -2,6 +2,7 @@ from .codec import real_time_codec
 from .brian import SymbolicOptimizer, analyze_and_repair
 from .aletheia_checker import find_typos
 from .meshkeeper import scan, render_voxels
+from .watchdog import watch
 from .feedback_ingest import categorize, Feedback
 from .alignment_guard import is_aligned, Change
 from .goal_selector import Goal, score_goals
@@ -17,6 +18,7 @@ __all__ = [
     "find_typos",
     "scan",
     "render_voxels",
+    "watch",
     "categorize",
     "Feedback",
     "is_aligned",

--- a/src/tsal/tools/watchdog.py
+++ b/src/tsal/tools/watchdog.py
@@ -1,0 +1,40 @@
+"""Minimal watchdog to trigger repair loops."""
+
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+
+from tsal.tools.brian import analyze_and_repair
+
+
+def watch(path: str = "src/tsal", interval: float = 30.0, cycles: int = 0, repair: bool = False) -> None:
+    """Monitor ``path`` and run analyze_and_repair on changed files."""
+    base = Path(path)
+    seen = {f: f.stat().st_mtime for f in base.rglob("*.py")}
+    count = 0
+    while True:
+        for file in base.rglob("*.py"):
+            mtime = file.stat().st_mtime
+            if file not in seen or mtime > seen[file]:
+                analyze_and_repair(str(file), repair=repair)
+                seen[file] = mtime
+        count += 1
+        if cycles and count >= cycles:
+            break
+        time.sleep(interval)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Continuous repair watchdog")
+    parser.add_argument("path", nargs="?", default="src/tsal")
+    parser.add_argument("--repair", action="store_true")
+    parser.add_argument("--interval", type=float, default=30.0)
+    parser.add_argument("--cycles", type=int, default=0)
+    args = parser.parse_args()
+    watch(args.path, interval=args.interval, cycles=args.cycles, repair=args.repair)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_tools/test_watchdog.py
+++ b/tests/unit/test_tools/test_watchdog.py
@@ -1,0 +1,7 @@
+from tsal.tools.watchdog import watch
+
+
+def test_watchdog_runs(tmp_path):
+    sample = tmp_path / "a.py"
+    sample.write_text("def a():\n    pass\n")
+    watch(str(tmp_path), interval=0, cycles=1)


### PR DESCRIPTION
## Summary
- add watchdog tool to monitor path and trigger repairs
- expose `watch` via tools package and CLI
- document command in README
- hook new CLI script in pyproject
- test watchdog utility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68455bbfd6048329917b0b0a55a450bb