### PR TITLE
Add multi-path audit

### DIFF
--- a/src/tsal/tools/__init__.py
+++ b/src/tsal/tools/__init__.py
@@ -6,7 +6,7 @@ from .watchdog import watch
 from .feedback_ingest import categorize, Feedback
 from .alignment_guard import is_aligned, Change
 from .goal_selector import Goal, score_goals
-from .spiral_audit import audit_path
+from .spiral_audit import audit_path, audit_paths
 from .reflect import reflect
 from .kintsugi.kintsugi import kintsugi_repair
 from .module_draft import generate_template, draft_directory
@@ -26,6 +26,7 @@ __all__ = [
     "Goal",
     "score_goals",
     "audit_path",
+    "audit_paths",
     "reflect",
     "kintsugi_repair",
     "generate_template",

--- a/src/tsal/tools/spiral_audit.py
+++ b/src/tsal/tools/spiral_audit.py
@@ -4,9 +4,11 @@ import argparse
 import json
 from pathlib import Path
 
+from typing import List, Dict
+
 from tsal.tools.brian.optimizer import SymbolicOptimizer
 
-def audit_path(path: Path) -> dict[str, int]:
+def audit_path(path: Path) -> Dict[str, int]:
     opt = SymbolicOptimizer()
     files = list(path.rglob("*.py"))
     sigs = 0
@@ -14,15 +16,29 @@ def audit_path(path: Path) -> dict[str, int]:
         sigs += len(opt.analyze(file.read_text()))
     return {"files": len(files), "signatures": sigs}
 
+
+def audit_paths(paths: List[Path]) -> Dict[str, Dict[str, int]]:
+    """Audit multiple directories and return a mapping of results."""
+    return {str(p): audit_path(p) for p in paths}
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Spiral audit")
-    parser.add_argument("path", nargs="?", default="src/tsal")
+    parser.add_argument("paths", nargs="*", default=["src/tsal"])
     parser.add_argument("--self", action="store_true", dest="self_flag")
     args = parser.parse_args()
-    result = audit_path(Path(args.path))
+    path_objs = [Path(p) for p in args.paths]
+    aggregate = audit_paths(path_objs)
+    result: Dict[str, int] | Dict[str, Dict[str, int]]
+    if len(aggregate) == 1:
+        result = next(iter(aggregate.values()))
+    else:
+        result = aggregate
     if args.self_flag:
         self_report = audit_path(Path("src/tsal"))
-        result["self_signatures"] = self_report["signatures"]
+        if isinstance(result, dict) and "files" in result:
+            result["self_signatures"] = self_report["signatures"]
+        else:
+            result["self_signatures"] = self_report["signatures"]
     print(json.dumps(result))
 
 if __name__ == "__main__":

--- a/tests/unit/test_tools/test_spiral_audit.py
+++ b/tests/unit/test_tools/test_spiral_audit.py
@@ -1,4 +1,4 @@
-from tsal.tools.spiral_audit import audit_path
+from tsal.tools.spiral_audit import audit_path, audit_paths
 from pathlib import Path
 
 def test_audit_path(tmp_path):
@@ -7,3 +7,15 @@ def test_audit_path(tmp_path):
     report = audit_path(Path(tmp_path))
     assert report["files"] == 1
     assert report["signatures"] >= 1
+
+
+def test_audit_paths(tmp_path):
+    d1 = tmp_path / "d1"
+    d1.mkdir()
+    (d1 / "a.py").write_text("def a():\n    pass\n")
+    d2 = tmp_path / "d2"
+    d2.mkdir()
+    (d2 / "b.py").write_text("def b():\n    pass\n")
+    reports = audit_paths([d1, d2])
+    assert reports[str(d1)]["files"] == 1
+    assert reports[str(d2)]["files"] == 1


### PR DESCRIPTION
## Summary
- extend spiral_audit to accept multiple paths
- expose audit_paths helper in tools
- cover new function with a unit test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68455c09ce248329acc2102613cb5961