### PR TITLE
Add grammar & humour DB utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,18 @@ python -m tsal.utils.language_db
 
 This creates `system_io.db` containing a `languages` table with all entries.
 
+To add basic grammar rules:
+
+```bash
+python -m tsal.utils.grammar_db
+```
+
+And a few sample jokes:
+
+```bash
+python -m tsal.utils.humour_db
+```
+
 Stub modules: `FEEDBACK.INGEST`, `ALIGNMENT.GUARD`, `GOAL.SELECTOR` ([!INTERNAL STUB]).
 
 This data can be supplied to Brian's optimizer when analyzing or repairing code.

--- a/src/tsal/utils/grammar_db.py
+++ b/src/tsal/utils/grammar_db.py
@@ -1,0 +1,48 @@
+import sqlite3
+from typing import Sequence, Optional
+
+DEFAULT_RULES = [
+    "noun",
+    "verb",
+    "adjective",
+    "adverb",
+    "preposition",
+    "conjunction",
+    "interjection",
+]
+
+
+def populate_grammar_db(
+    db_path: str = "system_io.db", rules: Optional[Sequence[str]] = None
+) -> int:
+    if rules is None:
+        rules = DEFAULT_RULES
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS grammar_rules (id INTEGER PRIMARY KEY AUTOINCREMENT, rule TEXT UNIQUE)"
+    )
+    cur.executemany(
+        "INSERT OR IGNORE INTO grammar_rules (rule) VALUES (?)",
+        [(r,) for r in rules],
+    )
+    conn.commit()
+    count = cur.execute("SELECT COUNT(*) FROM grammar_rules").fetchone()[0]
+    conn.close()
+    return count
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Populate grammar rules database")
+    parser.add_argument("--db", default="system_io.db", help="Path to SQLite database")
+    args = parser.parse_args(argv)
+
+    count = populate_grammar_db(args.db)
+    print(f"{count} rules stored in {args.db}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tsal/utils/humour_db.py
+++ b/src/tsal/utils/humour_db.py
@@ -1,0 +1,43 @@
+import sqlite3
+from typing import Sequence, Optional
+
+DEFAULT_JOKES = [
+    "Why did the chicken cross the road? To get to the other side.",
+    "I told my computer I needed a break, and it said 'No problem, I'll go to sleep.'",
+]
+
+
+def populate_humour_db(
+    db_path: str = "system_io.db", jokes: Optional[Sequence[str]] = None
+) -> int:
+    if jokes is None:
+        jokes = DEFAULT_JOKES
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "CREATE TABLE IF NOT EXISTS jokes (id INTEGER PRIMARY KEY AUTOINCREMENT, text TEXT UNIQUE)"
+    )
+    cur.executemany(
+        "INSERT OR IGNORE INTO jokes (text) VALUES (?)",
+        [(j,) for j in jokes],
+    )
+    conn.commit()
+    count = cur.execute("SELECT COUNT(*) FROM jokes").fetchone()[0]
+    conn.close()
+    return count
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Populate humour database")
+    parser.add_argument("--db", default="system_io.db", help="Path to SQLite database")
+    args = parser.parse_args(argv)
+
+    count = populate_humour_db(args.db)
+    print(f"{count} jokes stored in {args.db}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_utils/test_grammar_db.py
+++ b/tests/unit/test_utils/test_grammar_db.py
@@ -1,0 +1,15 @@
+from tsal.utils.grammar_db import populate_grammar_db
+import sqlite3
+
+
+def test_populate_grammar_db(tmp_path):
+    db = tmp_path / "grammar.db"
+    count = populate_grammar_db(db_path=str(db), rules=["rule_a", "rule_b"])
+    assert count == 2
+
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("SELECT rule FROM grammar_rules")
+    rows = {row[0] for row in cur.fetchall()}
+    conn.close()
+    assert rows == {"rule_a", "rule_b"}

--- a/tests/unit/test_utils/test_humour_db.py
+++ b/tests/unit/test_utils/test_humour_db.py
@@ -1,0 +1,15 @@
+from tsal.utils.humour_db import populate_humour_db
+import sqlite3
+
+
+def test_populate_humour_db(tmp_path):
+    db = tmp_path / "humour.db"
+    count = populate_humour_db(db_path=str(db), jokes=["j1", "j2"])
+    assert count == 2
+
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("SELECT text FROM jokes")
+    rows = {row[0] for row in cur.fetchall()}
+    conn.close()
+    assert rows == {"j1", "j2"}


### PR DESCRIPTION
## Summary
- add small SQLite helpers for grammar rules and jokes
- document the CLI commands in README
- test grammar_db and humour_db

## Testing
- `pytest tests/unit/test_utils/test_language_db.py tests/unit/test_utils/test_grammar_db.py tests/unit/test_utils/test_humour_db.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6845660c548083298358d56ecd9f1be9