### PR TITLE
Clarify failing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ pip install -e .
 ```bash
 pytest -q
 ```
+If this fails with `ModuleNotFoundError: numpy`, you skipped `pip install -r requirements.txt`.
+All 96 tests should then pass, covering the self‑audit loops and utilities.
 
 ## CLI Tools
 Run the optimizers and self-audit commands directly:


### PR DESCRIPTION
## Summary
- note that pytest fails if deps aren't installed
- specify all 96 tests should pass once requirements are installed

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68457eb9c0c48329ac7280d759ccf75a