### PR TITLE
Add Ko-Fi button to docs index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,3 +26,7 @@ For a summary of the current revision log:
 ```bash
 tsal-reflect
 ```
+
+## Support the project
+
+[![Ko-Fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/bikersam86)


### PR DESCRIPTION
## Summary
- show Ko-Fi link on docs homepage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68457f08ae6c83298f9165cdb045ac53