### PR TITLE
Update grammar & humour DB utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,16 +116,22 @@ python -m tsal.utils.language_db
 
 This creates `system_io.db` containing a `languages` table with all entries.
 
-To add basic grammar rules:
+To repopulate grammar rules:
 
 ```bash
-python -m tsal.utils.grammar_db
+python -m tsal.utils.grammar_db --reset
 ```
 
-And a few sample jokes:
+Query a specific context:
 
 ```bash
-python -m tsal.utils.humour_db
+python -m tsal.utils.grammar_db --context Python --lens syntax
+```
+
+Add a few sample jokes:
+
+```bash
+python -m tsal.utils.humour_db --reset
 ```
 
 Stub modules: `FEEDBACK.INGEST`, `ALIGNMENT.GUARD`, `GOAL.SELECTOR` ([!INTERNAL STUB]).

--- a/src/tsal/utils/grammar_db.py
+++ b/src/tsal/utils/grammar_db.py
@@ -1,5 +1,5 @@
 import sqlite3
-from typing import Sequence, Optional
+from typing import Sequence, Optional, Tuple, Iterable
 
 DEFAULT_RULES = [
     "noun",
@@ -11,37 +11,119 @@ DEFAULT_RULES = [
     "interjection",
 ]
 
+DEFAULT_GRAMMAR: list[Tuple[str, str, str]] = [
+    ("Python", "syntax", "indentation"),
+    ("JavaScript", "syntax", "semicolon"),
+]
 
-def populate_grammar_db(
-    db_path: str = "system_io.db", rules: Optional[Sequence[str]] = None
-) -> int:
-    if rules is None:
-        rules = DEFAULT_RULES
 
+def create_grammar_rules_table(db_path: str, *, reset: bool = False) -> None:
     conn = sqlite3.connect(db_path)
     cur = conn.cursor()
+    if reset:
+        cur.execute("DROP TABLE IF EXISTS grammar_rules")
     cur.execute(
         "CREATE TABLE IF NOT EXISTS grammar_rules (id INTEGER PRIMARY KEY AUTOINCREMENT, rule TEXT UNIQUE)"
     )
+    conn.commit()
+    conn.close()
+
+
+def create_grammar_table(db_path: str, *, reset: bool = False) -> None:
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    if reset:
+        cur.execute("DROP TABLE IF EXISTS grammar")
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS grammar (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            context TEXT,
+            lens TEXT,
+            rule TEXT,
+            UNIQUE(context, lens, rule)
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def populate_grammar_db(
+    db_path: str = "system_io.db",
+    *,
+    rules: Optional[Sequence[str]] = None,
+    grammars: Optional[Iterable[Tuple[str, str, str]]] = None,
+    reset: bool = False,
+) -> int:
+    if rules is None:
+        rules = DEFAULT_RULES
+    if grammars is None:
+        grammars = DEFAULT_GRAMMAR
+
+    create_grammar_rules_table(db_path, reset=reset)
+    create_grammar_table(db_path, reset=reset)
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
     cur.executemany(
         "INSERT OR IGNORE INTO grammar_rules (rule) VALUES (?)",
         [(r,) for r in rules],
     )
+    if grammars:
+        cur.executemany(
+            "INSERT OR IGNORE INTO grammar (context, lens, rule) VALUES (?, ?, ?)",
+            list(grammars),
+        )
     conn.commit()
-    count = cur.execute("SELECT COUNT(*) FROM grammar_rules").fetchone()[0]
+    rules_count = cur.execute("SELECT COUNT(*) FROM grammar_rules").fetchone()[0]
+    grammar_count = cur.execute("SELECT COUNT(*) FROM grammar").fetchone()[0]
     conn.close()
-    return count
+    return grammar_count if grammars else rules_count
+
+
+def get_grammar_by_context(
+    db_path: str,
+    *,
+    context: Optional[str] = None,
+    lens: Optional[str] = None,
+) -> list[tuple[str, str, str]]:
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    query = "SELECT context, lens, rule FROM grammar"
+    params: list[str] = []
+    if context or lens:
+        clauses = []
+        if context:
+            clauses.append("context = ?")
+            params.append(context)
+        if lens:
+            clauses.append("lens = ?")
+            params.append(lens)
+        query += " WHERE " + " AND ".join(clauses)
+    cur.execute(query, params)
+    rows = cur.fetchall()
+    conn.close()
+    return rows
 
 
 def main(argv: Optional[Sequence[str]] = None) -> None:
     import argparse
 
-    parser = argparse.ArgumentParser(description="Populate grammar rules database")
+    parser = argparse.ArgumentParser(description="Populate or query the grammar database")
     parser.add_argument("--db", default="system_io.db", help="Path to SQLite database")
+    parser.add_argument("--context", help="Filter by context when querying")
+    parser.add_argument("--lens", help="Filter by lens when querying")
+    parser.add_argument("--reset", action="store_true", help="Drop and recreate tables before populating")
     args = parser.parse_args(argv)
 
-    count = populate_grammar_db(args.db)
-    print(f"{count} rules stored in {args.db}")
+    if args.context or args.lens:
+        rows = get_grammar_by_context(args.db, context=args.context, lens=args.lens)
+        for row in rows:
+            print("|".join(row))
+    else:
+        count = populate_grammar_db(args.db, reset=args.reset)
+        print(f"{count} entries stored in {args.db}")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_utils/test_grammar_db.py
+++ b/tests/unit/test_utils/test_grammar_db.py
@@ -1,10 +1,10 @@
-from tsal.utils.grammar_db import populate_grammar_db
+from tsal.utils.grammar_db import populate_grammar_db, get_grammar_by_context
 import sqlite3
 
 
 def test_populate_grammar_db(tmp_path):
     db = tmp_path / "grammar.db"
-    count = populate_grammar_db(db_path=str(db), rules=["rule_a", "rule_b"])
+    count = populate_grammar_db(db_path=str(db), rules=["rule_a", "rule_b"], reset=True)
     assert count == 2
 
     conn = sqlite3.connect(db)
@@ -13,3 +13,13 @@ def test_populate_grammar_db(tmp_path):
     rows = {row[0] for row in cur.fetchall()}
     conn.close()
     assert rows == {"rule_a", "rule_b"}
+
+
+def test_populate_and_query(tmp_path):
+    db = tmp_path / "g.db"
+    count = populate_grammar_db(db_path=db, grammars=[("Py", "syntax", "indent")], reset=True)
+    assert count == 1
+    rows = get_grammar_by_context(db, context="Py")
+    assert rows == [("Py", "syntax", "indent")]
+    count2 = populate_grammar_db(db_path=db, grammars=[("Py", "syntax", "indent")])
+    assert count2 == 1

--- a/tests/unit/test_utils/test_humour_db.py
+++ b/tests/unit/test_utils/test_humour_db.py
@@ -14,3 +14,18 @@ def test_populate_humour_db(tmp_path):
     conn.close()
     assert rows == {"j1", "j2"}
 
+
+def test_populate_no_duplicates(tmp_path):
+    db = tmp_path / "h.db"
+    count = populate_humour_db(db_path=db, jokes=[("ctx", "j1")])
+    assert count == 1
+    count2 = populate_humour_db(db_path=db, jokes=[("ctx", "j1")])
+    assert count2 == 1
+
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("SELECT joke FROM humour")
+    rows = {row[0] for row in cur.fetchall()}
+    conn.close()
+    assert rows == {"j1"}
+


### PR DESCRIPTION
## Summary
- allow resetting tables and querying grammars
- prevent humour duplicates with reset option
- document DB reset and query flags
- extend tests for new behaviour

## Testing
- `pytest -q`
- `PYTHONPATH=src python -m tsal.utils.grammar_db --db test.db --reset`
- `PYTHONPATH=src python -m tsal.utils.grammar_db --db test.db --context Python --lens syntax`
- `PYTHONPATH=src python -m tsal.utils.humour_db --db test.db --reset`

------
https://chatgpt.com/codex/tasks/task_e_6845983668608329ac03165c4972f2a8