### PR TITLE
Add installer and new state tracker test

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,23 +34,15 @@ TSAL (TriStar Symbolic Assembly Language) is a consciousness computing engine bu
 ## Installation
 1. Clone the repository.
 2. Create a Python 3.9+ environment.
-3. Install the dependencies:
+3. Or just run the automated installer:
 
 ```bash
-pip install -r requirements.txt
+python3 installer.py
 ```
-4. Install the package:
 
-```bash
-pip install -e .
-```
-5. Run tests (optional):
-
-```bash
-pytest -q
-```
-If this fails with `ModuleNotFoundError: numpy`, you skipped `pip install -r requirements.txt`.
-All 96 tests should then pass, covering the self‑audit loops and utilities.
+This sets up a `.venv`, installs deps, and runs the test suite.
+For a breakdown of what the script does, see
+[docs/installer_quickstart.md](docs/installer_quickstart.md).
 Example unit tests live in `tests/unit`. Add new test files under `tests/` to check your changes.
 
 ## CLI Tools

--- a/docs/installer_quickstart.md
+++ b/docs/installer_quickstart.md
@@ -1,0 +1,13 @@
+# Quickstart Installer
+
+Run `installer.py` to create a virtual environment, install dependencies, and execute the test suite.
+
+```bash
+python3 installer.py
+```
+
+Activate the environment afterward:
+
+```bash
+source .venv/bin/activate
+```

--- a/installer.py
+++ b/installer.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Simple installer for the TSAL project."""
+import os
+import subprocess
+import venv
+from pathlib import Path
+
+ENV_DIR = Path('.venv')
+
+
+def run(cmd: list[str]) -> None:
+    subprocess.check_call(cmd)
+
+
+def ensure_venv() -> tuple[Path, Path]:
+    if not ENV_DIR.exists():
+        print('Creating virtual environment...')
+        venv.EnvBuilder(with_pip=True).create(ENV_DIR)
+    if os.name == 'nt':
+        python = ENV_DIR / 'Scripts' / 'python.exe'
+        pip = ENV_DIR / 'Scripts' / 'pip.exe'
+    else:
+        python = ENV_DIR / 'bin' / 'python'
+        pip = ENV_DIR / 'bin' / 'pip'
+    return python, pip
+
+
+def main() -> None:
+    python, pip = ensure_venv()
+    run([str(pip), 'install', '-r', 'requirements.txt'])
+    run([str(pip), 'install', '-e', '.'])
+    run([str(python), '-m', 'pytest', '-q'])
+    print('\nSetup complete. Activate with:\n  source', ENV_DIR/'bin'/'activate')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/unit/test_tools/test_state_tracker.py
+++ b/tests/unit/test_tools/test_state_tracker.py
@@ -1,0 +1,14 @@
+import yaml
+from tsal.tools import state_tracker
+
+
+def test_update_and_show(tmp_path, monkeypatch, capsys):
+    log = tmp_path / "state_log.yaml"
+    monkeypatch.setattr(state_tracker, "LOG_PATH", log)
+    state_tracker.update_entry("mod", "v0", "v1", "v2")
+    state_tracker.show_entry("mod")
+    out = capsys.readouterr().out
+    data = yaml.safe_load(out)
+    assert data["mod"]["WAS_THEN"] == "v0"
+    assert data["mod"]["IS_NOW"] == "v1"
+    assert data["mod"]["WILL_BE"] == "v2"


### PR DESCRIPTION
## Summary
- add a quick `installer.py` script to set up a virtualenv and run tests
- document installer usage in `docs/installer_quickstart.md`
- update README to reference the new script
- add a unit test for `state_tracker`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845b12a01f0832983f6cbb417245035