### PR TITLE
Extend party tricks with physics functions

### DIFF
--- a/src/tsal/tools/party_tricks.py
+++ b/src/tsal/tools/party_tricks.py
@@ -7,7 +7,13 @@ import inspect
 import random
 from typing import Callable, Dict, Tuple, Any
 
-from tsal.core.phi_math import corrected_energy
+from tsal.core.phi_math import (
+    corrected_energy,
+    phi_wavefunction,
+    phase_alignment_potential,
+    orbital_radius,
+)
+from tsal.core.intent_metric import calculate_idm
 from tsal.core.spiral_vector import phi_alignment
 from tsal.core.symbols import get_symbol
 
@@ -36,10 +42,46 @@ def symbol_trick(symbol: str = "PHI") -> tuple:
     return get_symbol(code) if code is not None else ("?", symbol, "Unknown")
 
 
+def wavefunction_trick(
+    phi: float = 0.0, phi_vacuum: float = 0.0, lam: float = 1.0
+) -> float:
+    """Return φ wavefunction value."""
+    return phi_wavefunction(phi, phi_vacuum, lam)
+
+
+def potential_trick(
+    phi: float = 0.0, phi_vacuum: float = 0.0, lam: float = 1.0
+) -> float:
+    """Return phase alignment potential."""
+    return phase_alignment_potential(phi, phi_vacuum, lam)
+
+
+def radius_trick(n: int = 1, phi: float = 0.0) -> float:
+    """Return orbital radius."""
+    return orbital_radius(n, phi)
+
+
+def idm_trick(
+    info_quality: float = 1.0,
+    info_quantity: float = 1.0,
+    accuracy: float = 1.0,
+    complexity: float = 1.0,
+    time_taken: float = 1.0,
+) -> float:
+    """Return Intent-Driven Metric score."""
+    return calculate_idm(
+        info_quality, info_quantity, accuracy, complexity, time_taken
+    )
+
+
 Func_yTown: Dict[str, Tuple[Callable[..., Any], str]] = {
     "orbital": (orbital_trick, "Calculate orbital energy"),
     "phi-align": (phi_trick, "Phi alignment score"),
     "symbol": (symbol_trick, "TSAL symbol lookup"),
+    "wavefunction": (wavefunction_trick, "φ wavefunction"),
+    "potential": (potential_trick, "Phase alignment potential"),
+    "radius": (radius_trick, "Orbital radius"),
+    "idm": (idm_trick, "Intent metric"),
 }
 
 

--- a/tests/unit/test_party_tricks.py
+++ b/tests/unit/test_party_tricks.py
@@ -9,3 +9,23 @@ def test_orbital_trick():
 def test_phi_trick():
     score = run_trick("phi-align", complexity=1.0, coherence=0.0)
     assert isinstance(score, float)
+
+
+def test_wavefunction_trick():
+    val = run_trick("wavefunction", phi=0.1)
+    assert isinstance(val, float)
+
+
+def test_potential_trick():
+    val = run_trick("potential", phi=0.1)
+    assert isinstance(val, float)
+
+
+def test_radius_trick():
+    val = run_trick("radius", n=2, phi=0.1)
+    assert isinstance(val, float)
+
+
+def test_idm_trick():
+    score = run_trick("idm", info_quality=0.9, info_quantity=1.0, accuracy=0.8, complexity=1.0, time_taken=1.0)
+    assert isinstance(score, float)


### PR DESCRIPTION
## Summary
- add phi wavefunction, potential, orbital radius and IDM helpers
- expose them via `Func_yTown`
- test new tricks

## Testing
- `pytest tests/unit/test_party_tricks.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d78fe2948329a307e4254c0c0cdc