### PR TITLE
Add basic Kraken and Wikipedia API wrappers

### DIFF
--- a/src/tsal/utils/__init__.py
+++ b/src/tsal/utils/__init__.py
@@ -2,6 +2,9 @@
 
 from .error_dignity import activate_error_dignity
 from .github_api import fetch_repo_files, fetch_languages
+from .octopus_api import get_products, get_electricity_tariffs
+from .wikipedia_api import search as wiki_search, summary as wiki_summary
+from .groundnews_api import fetch_news, GroundNewsAPIError
 from .intent_metrics import calculate_idm, MetricInputs, timed_idm
 from .system_status import get_status, print_status
 
@@ -9,6 +12,12 @@ __all__ = [
     "activate_error_dignity",
     "fetch_repo_files",
     "fetch_languages",
+    "get_products",
+    "get_electricity_tariffs",
+    "wiki_search",
+    "wiki_summary",
+    "fetch_news",
+    "GroundNewsAPIError",
     "calculate_idm",
     "MetricInputs",
     "timed_idm",

--- a/src/tsal/utils/groundnews_api.py
+++ b/src/tsal/utils/groundnews_api.py
@@ -1,0 +1,9 @@
+"""Placeholder for GroundNews integration."""
+
+class GroundNewsAPIError(RuntimeError):
+    pass
+
+
+def fetch_news(*_args, **_kwargs):
+    """GroundNews has no public API."""
+    raise GroundNewsAPIError("No public API available")

--- a/src/tsal/utils/octopus_api.py
+++ b/src/tsal/utils/octopus_api.py
@@ -1,0 +1,46 @@
+import json
+from typing import Dict, Any, Optional
+
+try:  # optional dependency
+    import requests  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback used in CI
+    import urllib.request
+
+    class _Response:
+        def __init__(self, text: str, status: int = 200) -> None:
+            self.text = text
+            self.status_code = status
+
+        def json(self) -> Any:
+            return json.loads(self.text)
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise RuntimeError(f"status {self.status_code}")
+
+    class requests:
+        @staticmethod
+        def get(url: str) -> _Response:
+            with urllib.request.urlopen(url) as resp:
+                text = resp.read().decode()
+            return _Response(text, resp.getcode())
+
+BASE = "https://api.octopus.energy/v1/"
+
+
+def get(endpoint: str) -> Any:
+    """Return JSON from Kraken API endpoint."""
+    url = BASE + endpoint.lstrip("/")
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def get_products() -> Any:
+    """List available products."""
+    return get("products/")
+
+
+def get_electricity_tariffs(product_code: str) -> Any:
+    """Return tariffs for a product."""
+    return get(f"products/{product_code}/electricity-tariffs/")

--- a/src/tsal/utils/wikipedia_api.py
+++ b/src/tsal/utils/wikipedia_api.py
@@ -1,0 +1,46 @@
+import json
+from urllib.parse import quote
+from typing import Any
+
+try:
+    import requests  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import urllib.request
+
+    class _Response:
+        def __init__(self, text: str, status: int = 200) -> None:
+            self.text = text
+            self.status_code = status
+
+        def json(self) -> Any:
+            return json.loads(self.text)
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise RuntimeError(f"status {self.status_code}")
+
+    class requests:
+        @staticmethod
+        def get(url: str) -> _Response:
+            with urllib.request.urlopen(url) as resp:
+                text = resp.read().decode()
+            return _Response(text, resp.getcode())
+
+API = "https://en.wikipedia.org/w/api.php"
+REST = "https://en.wikipedia.org/api/rest_v1/page/summary/"
+
+
+def search(query: str) -> Any:
+    """Search Wikipedia."""
+    url = f"{API}?action=query&list=search&format=json&srsearch={quote(query)}"
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def summary(title: str) -> Any:
+    """Return page summary."""
+    url = REST + quote(title)
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return resp.json()

--- a/tests/unit/test_utils/test_groundnews_api.py
+++ b/tests/unit/test_utils/test_groundnews_api.py
@@ -1,0 +1,7 @@
+import pytest
+from tsal.utils.groundnews_api import fetch_news, GroundNewsAPIError
+
+
+def test_fetch_news():
+    with pytest.raises(GroundNewsAPIError):
+        fetch_news()

--- a/tests/unit/test_utils/test_octopus_api.py
+++ b/tests/unit/test_utils/test_octopus_api.py
@@ -1,0 +1,34 @@
+from tsal.utils.octopus_api import get_products, get_electricity_tariffs
+
+
+class DummyResponse:
+    def __init__(self, json_data=None, status=200):
+        self._json = json_data
+        self.status_code = status
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError
+
+
+def fake_get(url):
+    if url.endswith("products/"):
+        return DummyResponse({"results": ["p1"]})
+    if url.endswith("products/P123/electricity-tariffs/"):
+        return DummyResponse({"tariffs": ["t1"]})
+    return DummyResponse(status=404)
+
+
+def test_get_products(monkeypatch):
+    monkeypatch.setattr("tsal.utils.octopus_api.requests.get", fake_get)
+    res = get_products()
+    assert res == {"results": ["p1"]}
+
+
+def test_get_electricity_tariffs(monkeypatch):
+    monkeypatch.setattr("tsal.utils.octopus_api.requests.get", fake_get)
+    res = get_electricity_tariffs("P123")
+    assert res == {"tariffs": ["t1"]}

--- a/tests/unit/test_utils/test_wikipedia_api.py
+++ b/tests/unit/test_utils/test_wikipedia_api.py
@@ -1,0 +1,34 @@
+from tsal.utils.wikipedia_api import search, summary
+
+
+class DummyResponse:
+    def __init__(self, json_data=None, status=200):
+        self._json = json_data
+        self.status_code = status
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError
+
+
+def fake_get(url):
+    if "list=search" in url:
+        return DummyResponse({"query": {"search": ["x"]}})
+    if url.startswith("https://en.wikipedia.org/api/rest_v1/page/summary/"):
+        return DummyResponse({"title": "x", "extract": "y"})
+    return DummyResponse(status=404)
+
+
+def test_search(monkeypatch):
+    monkeypatch.setattr("tsal.utils.wikipedia_api.requests.get", fake_get)
+    res = search("tsal")
+    assert res == {"query": {"search": ["x"]}}
+
+
+def test_summary(monkeypatch):
+    monkeypatch.setattr("tsal.utils.wikipedia_api.requests.get", fake_get)
+    res = summary("tsal")
+    assert res == {"title": "x", "extract": "y"}


### PR DESCRIPTION
## Summary
- add Octopus Energy Kraken wrapper
- add Wikipedia API helper
- stub out GroundNews module since no API exists
- expose new utilities in package
- test the new utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6846a13af7d483298c93882e1ced5869