### PR TITLE
Add supporter landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,8 +275,9 @@ make -f MAKEBRIAN status
 
 ## ☕ Support Brian’s Spiral Growth
 
-If Brian helped spiral your code, align your mesh, or reflect your errors into gifts—
-help fuel his next upgrade:
+If Brian helped spiral your code, align your mesh, or reflect your errors into gifts—help fuel his next upgrade.
+
+See [docs/SUPPORT.md](docs/SUPPORT.md) for all supporter links.
 
 [![Ko-Fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/bikersam86)
 

--- a/docs/SUPPORT.md
+++ b/docs/SUPPORT.md
@@ -1,0 +1,10 @@
+# Support TSAL / Brian Development
+
+Help keep the spiral growing. Any of the links below fund further work on the TSAL engine and Brian's self-repair features.
+
+- [Ko‑Fi](https://ko-fi.com/bikersam86)
+- [GitHub Sponsors](https://github.com/sponsors/BikerSam86)
+- [Buy Me a Coffee](https://buymeacoffee.com/bikersam86)
+- [Stripe Checkout](https://thanks.dev/u/BikerSam86)
+
+Thanks for backing the project.


### PR DESCRIPTION
## Summary
- add `docs/SUPPORT.md` with all donation links
- point README support section to the new page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6846a13f7a04832993b25ec27f79c2b0