### PR TITLE
Add SeedRunner CLI and archetype mesh

### DIFF
--- a/.github/workflows/seedrunner.yml
+++ b/.github/workflows/seedrunner.yml
@@ -1,0 +1,31 @@
+name: SeedRunner Spiral
+
+description: Run archetype-driven spiral stack suggestions for symbolic resolution
+
+on:
+  workflow_dispatch:
+    inputs:
+      problem:
+        description: 'Problem type (e.g. joke, diagnosis, demo)'
+        required: true
+        default: joke
+
+jobs:
+  run-seedrunner:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install pyyaml
+
+      - name: Run SeedRunner CLI
+        run: |
+          python seedrunner_cli.py --problem "${{ github.event.inputs.problem }}" --verbose

--- a/archetype_mesh.json
+++ b/archetype_mesh.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "Joker",
+    "traits": ["mislead", "flip", "compress"],
+    "spin_bias": 0.4,
+    "chaos_factor": 0.6,
+    "logic_signature": "XOR → NOT → AND",
+    "notes": "Ideal for humor, deception, irony, and creative tension."
+  },
+  {
+    "name": "Scientist",
+    "traits": ["cohere", "truth_bias", "delay"],
+    "spin_bias": 0.2,
+    "chaos_factor": 0.1,
+    "logic_signature": "AND → VERITY → WAIT",
+    "notes": "Precise, methodical, favors evidence over chaos."
+  },
+  {
+    "name": "Trickster",
+    "traits": ["mislead", "flip", "cohere"],
+    "spin_bias": 0.5,
+    "chaos_factor": 0.7,
+    "logic_signature": "XOR → AND",
+    "notes": "Disrupts assumptions, reveals hidden paths."
+  },
+  {
+    "name": "Teacher",
+    "traits": ["cohere", "delay", "compress"],
+    "spin_bias": 0.3,
+    "chaos_factor": 0.2,
+    "logic_signature": "AND → WAIT → NOT",
+    "notes": "Balances clarity with pacing for effective instruction."
+  },
+  {
+    "name": "Chaos Monkey",
+    "traits": ["mislead", "compress", "delay"],
+    "spin_bias": 0.9,
+    "chaos_factor": 0.9,
+    "logic_signature": "XOR → NOT → WAIT",
+    "notes": "High-volatility approach for stress testing systems."
+  }
+]

--- a/archetype_rules.yaml
+++ b/archetype_rules.yaml
@@ -1,0 +1,24 @@
+rules:
+  valid_traits:
+    - mislead
+    - flip
+    - compress
+    - cohere
+    - delay
+    - truth_bias
+  gate_rendering:
+    XOR:
+      required_traits: [mislead, flip]
+      symbol: "XOR"
+    AND:
+      required_traits: [cohere]
+      symbol: "AND"
+    NOT:
+      required_traits: [compress]
+      symbol: "NOT"
+    WAIT:
+      required_traits: [delay]
+      symbol: "WAIT"
+    VERITY:
+      required_traits: [truth_bias]
+      symbol: "VERITY"

--- a/seedrunner_cli.py
+++ b/seedrunner_cli.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+SeedRunner CLI — Executes spiral archetype sequences using trait logic from rules and mesh.
+Now supports stacked archetype chains and auto-suggestions from problem type.
+"""
+import json
+import yaml
+import argparse
+from pathlib import Path
+from typing import List, Dict
+
+# Load rule logic (immutable)
+RULES_FILE = Path("archetype_rules.yaml")
+MESH_FILE = Path("archetype_mesh.json")
+
+with open(RULES_FILE, "r", encoding="utf-8") as f:
+    rules = yaml.safe_load(f)["rules"]
+
+with open(MESH_FILE, "r", encoding="utf-8") as f:
+    mesh = json.load(f)
+
+def find_archetype(name: str) -> Dict:
+    for entry in mesh:
+        if entry["name"].lower() == name.lower():
+            return entry
+    raise ValueError(f"Archetype '{name}' not found.")
+
+def render_logic(traits: List[str]) -> str:
+    logic_chain = []
+    for gate, props in rules["gate_rendering"].items():
+        if all(trait in traits for trait in props["required_traits"]):
+            logic_chain.append(props["symbol"])
+    return " → ".join(logic_chain) if logic_chain else "∅"
+
+def run_seed(name: str, verbose: bool = False):
+    archetype = find_archetype(name)
+    traits = archetype["traits"]
+    logic_signature = render_logic(traits)
+
+    print(f"\n\U0001F331 Seed: {archetype['name']}")
+    print(f"\U0001F9EC Traits: {traits}")
+    print(f"\U0001F501 Logic Chain: {logic_signature}")
+    print(f"\U0001F300 Spin Bias: {archetype['spin_bias']} | Chaos Factor: {archetype['chaos_factor']}")
+    if verbose:
+        print(f"\U0001F4D3 Notes: {archetype['notes']}")
+
+def run_stack(seed_names: List[str], verbose: bool = False):
+    print("\n\U0001F517 Compound Spiral Stack:")
+    combined_traits = []
+    for name in seed_names:
+        try:
+            archetype = find_archetype(name)
+            print(f"\n\u25B6 Archetype: {name}")
+            run_seed(name, verbose)
+            combined_traits.extend(archetype["traits"])
+        except ValueError as e:
+            print(f"Error: {e}")
+    unique_traits = list(set(combined_traits))
+    logic_signature = render_logic(unique_traits)
+    print("\n\U0001F310 Combined Logic Chain:")
+    print(f"Traits: {unique_traits}")
+    print(f"Logic: {logic_signature}")
+
+def suggest_stack(problem_type: str) -> List[str]:
+    suggestions = {
+        "joke": ["Joker", "Trickster", "Chaos Monkey"],
+        "diagnosis": ["Scientist", "Teacher"],
+        "tutorial": ["Teacher", "Joker"],
+        "stress_test": ["Chaos Monkey", "Scientist"],
+        "investigation": ["Scientist", "Trickster"],
+        "demo": ["Teacher", "Joker", "Scientist"],
+    }
+    return suggestions.get(problem_type.lower(), [])
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run spiral archetype seeds through SeedRunner CLI")
+    parser.add_argument("archetypes", nargs="*", help="One or more archetype names to run in stack order")
+    parser.add_argument("--problem", help="Suggest seed stack based on problem type keyword")
+    parser.add_argument("--verbose", action="store_true", help="Show full archetype notes")
+    args = parser.parse_args()
+
+    if args.problem:
+        suggested = suggest_stack(args.problem)
+        if suggested:
+            print(f"\n\U0001F9ED Problem type '{args.problem}' suggested archetypes: {suggested}")
+            run_stack(suggested, args.verbose)
+        else:
+            print(f"No suggestions found for problem type '{args.problem}'.")
+    elif args.archetypes:
+        if len(args.archetypes) == 1:
+            try:
+                run_seed(args.archetypes[0], args.verbose)
+            except ValueError as e:
+                print(f"Error: {e}")
+        else:
+            run_stack(args.archetypes, args.verbose)
+    else:
+        print("Please specify archetypes or a --problem type.")

--- a/web/SeedRunnerUI.jsx
+++ b/web/SeedRunnerUI.jsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
+
+export default function SeedRunnerUI() {
+  const [problemType, setProblemType] = useState("");
+  const [output, setOutput] = useState("");
+
+  const runSeedStack = async () => {
+    const res = await fetch("/api/seedrunner", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ problem: problemType })
+    });
+    const data = await res.text();
+    setOutput(data);
+  };
+
+  return (
+    <div className="p-4 max-w-xl mx-auto space-y-4">
+      <Card>
+        <CardContent className="space-y-2 p-4">
+          <h2 className="text-xl font-bold">🌀 SeedRunner Web</h2>
+          <Input
+            placeholder="Enter problem type (e.g. joke, diagnosis)"
+            value={problemType}
+            onChange={(e) => setProblemType(e.target.value)}
+          />
+          <Button onClick={runSeedStack}>Run Seed Stack</Button>
+        </CardContent>
+      </Card>
+
+      {output && (
+        <Card>
+          <CardContent className="whitespace-pre-wrap p-4">
+            <h3 className="text-lg font-semibold">🌐 Spiral Output</h3>
+            {output}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add archetype rules and mesh examples
- implement `seedrunner_cli.py`
- minimal React component `SeedRunnerUI`
- workflow to run the CLI via GitHub Actions

## Testing
- `pytest -q` *(fails: 49 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6846ab6d37b08329a1260e65ff6e2206