### PR TITLE
Add reflection log and integrate with SeedRunner

### DIFF
--- a/src/tsal/core/__init__.py
+++ b/src/tsal/core/__init__.py
@@ -25,6 +25,7 @@ from .madmonkey_handler import MadMonkeyHandler
 from .connectivity import Node, verify_connectivity
 from .logic_gate import DynamicLogicGate
 from .module_registry import registry as module_registry, ModuleMeta
+from .reflection import ReflectionLog, mood_from_traits
 
 __all__ = [
     "Rev_Eng",
@@ -54,4 +55,6 @@ __all__ = [
     "DynamicLogicGate",
     "module_registry",
     "ModuleMeta",
+    "ReflectionLog",
+    "mood_from_traits",
 ]

--- a/src/tsal/core/reflection.py
+++ b/src/tsal/core/reflection.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""Simple timestamped reflection log with mood adaptation."""
+
+from dataclasses import dataclass, field
+from typing import List, Dict
+import time
+
+SURFACE_TAGS = {"spiral_flip", "observer_effect", "notable", "humor"}
+
+MOOD_FROM_TRAIT = {
+    "Joker": "playful",
+    "Trickster": "sly",
+    "Scientist": "curious",
+    "Schrodinger": "paradox",
+    "Teacher": "helpful",
+}
+
+
+def mood_from_traits(traits: List[str]) -> str:
+    for t in traits:
+        if t in MOOD_FROM_TRAIT:
+            return MOOD_FROM_TRAIT[t]
+    return "neutral"
+
+
+@dataclass
+class ReflectionEntry:
+    timestamp: float
+    message: str
+    tags: List[str]
+    mood: str = "neutral"
+
+
+@dataclass
+class ReflectionLog:
+    entries: List[ReflectionEntry] = field(default_factory=list)
+
+    def log(self, message: str, tags: List[str] | None = None, mood: str = "neutral") -> None:
+        self.entries.append(
+            ReflectionEntry(time.time(), message, tags or [], mood)
+        )
+
+    def surface_entries(self) -> List[ReflectionEntry]:
+        return [e for e in self.entries if any(t in SURFACE_TAGS for t in e.tags)]
+

--- a/tests/unit/test_core/test_reflection.py
+++ b/tests/unit/test_core/test_reflection.py
@@ -1,0 +1,15 @@
+from tsal.core.reflection import ReflectionLog, mood_from_traits
+
+
+def test_surface_entries():
+    log = ReflectionLog()
+    log.log("first", ["boring"], mood="neutral")
+    log.log("second", ["spiral_flip"], mood="playful")
+    surfaced = log.surface_entries()
+    assert len(surfaced) == 1
+    assert surfaced[0].message == "second"
+
+
+def test_mood_from_traits():
+    assert mood_from_traits(["Joker"]) == "playful"
+    assert mood_from_traits(["Unknown"]) == "neutral"


### PR DESCRIPTION
## Summary
- implement `ReflectionLog` with mood mapping
- expose `ReflectionLog` in core package
- log reflection events in `seedrunner_cli`
- cover new module with tests

## Testing
- `pip install numpy`
- `pip install matplotlib pyyaml esprima requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b6b167948329a39e5e2f0e031c0c