### PR TITLE
Enhance reflection log

### DIFF
--- a/tests/unit/test_core/test_reflection.py
+++ b/tests/unit/test_core/test_reflection.py
@@ -13,3 +13,9 @@ def test_surface_entries():
 def test_mood_from_traits():
     assert mood_from_traits(["Joker"]) == "playful"
     assert mood_from_traits(["Unknown"]) == "neutral"
+
+
+def test_spiral_hash_changes():
+    log1 = ReflectionLog(state="a", spin="x")
+    log2 = ReflectionLog(state="b", spin="x")
+    assert log1.spiral_hash != log2.spiral_hash


### PR DESCRIPTION
## Summary
- extend `ReflectionLog` with pace/rate/state/spin metadata
- compute `spiral_hash` from those values
- allow logs to flush to disk with dynamic path logic
- test spiral hash generation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6846b6ea7ca4832980929c4ab8eb36ff