### PR TITLE
Add archetype fetcher and reflection markdown

### DIFF
--- a/seedrunner_cli.py
+++ b/seedrunner_cli.py
@@ -12,6 +12,7 @@ import time
 from pathlib import Path
 from typing import List, Dict, Optional, Any
 from tsal.core import ReflectionLog, mood_from_traits
+from tsal.tools.archetype_fetcher import fetch_online_mesh, merge_mesh
 
 # Load rule logic (immutable)
 RULES_FILE = Path("archetype_rules.yaml")
@@ -154,7 +155,18 @@ def main() -> None:
     parser.add_argument("--replay", metavar="HASH", help="Replay cached stack by hash")
     parser.add_argument("--lang", help="Localization language tag (e.g. fr)")
     parser.add_argument("--pronounce", action="store_true", help="Show IPA pronunciation")
+    parser.add_argument("--fetch", metavar="URL", help="Fetch archetype mesh from URL")
     args = parser.parse_args()
+
+    global mesh
+
+    if args.fetch:
+        try:
+            new_mesh = fetch_online_mesh(args.fetch)
+            merge_mesh(MESH_FILE, new_mesh)
+            mesh = json.loads(MESH_FILE.read_text())
+        except Exception as e:
+            print(f"Fetch failed: {e}")
 
     cache = load_cache()
     stack_hash = ""

--- a/src/tsal/core/reflection.py
+++ b/src/tsal/core/reflection.py
@@ -79,3 +79,26 @@ class ReflectionLog:
     def surface_entries(self) -> List[ReflectionEntry]:
         return [e for e in self.entries if any(t in SURFACE_TAGS for t in e.tags)]
 
+    def to_markdown(self) -> str:
+        """Return entries formatted as markdown bullet list."""
+        lines = []
+        for e in self.entries:
+            ts = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(e.timestamp))
+            lines.append(f"- {ts} [{e.mood}] {e.message}")
+        return "\n".join(lines)
+
+    def emit_mesh(self) -> None:
+        """Send entries to mesh_logger."""
+        from . import mesh_logger
+
+        for e in self.entries:
+            mesh_logger.log_event(
+                "REFLECTION",
+                {
+                    "message": e.message,
+                    "mood": e.mood,
+                    "tags": e.tags,
+                },
+                origin="ReflectionLog",
+            )
+

--- a/src/tsal/tools/__init__.py
+++ b/src/tsal/tools/__init__.py
@@ -11,6 +11,7 @@ from .reflect import reflect
 from .kintsugi.kintsugi import kintsugi_repair
 from .module_draft import generate_template, draft_directory
 from .state_tracker import update_entry, show_entry
+from .archetype_fetcher import fetch_online_mesh, merge_mesh
 
 __all__ = [
     "real_time_codec",
@@ -34,4 +35,6 @@ __all__ = [
     "draft_directory",
     "update_entry",
     "show_entry",
+    "fetch_online_mesh",
+    "merge_mesh",
 ]

--- a/src/tsal/tools/archetype_fetcher.py
+++ b/src/tsal/tools/archetype_fetcher.py
@@ -1,0 +1,44 @@
+import json
+from pathlib import Path
+from typing import List, Dict
+
+try:
+    import requests
+except ModuleNotFoundError:  # pragma: no cover - fallback
+    import urllib.request as _u
+
+    class _Resp:
+        def __init__(self, text: str, status: int = 200) -> None:
+            self.text = text
+            self.status_code = status
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise RuntimeError(f"status {self.status_code}")
+
+    class requests:
+        @staticmethod
+        def get(url: str) -> _Resp:
+            with _u.urlopen(url) as f:
+                return _Resp(f.read().decode(), f.getcode())
+
+
+def fetch_online_mesh(url: str) -> List[Dict]:
+    """Fetch archetype mesh entries from ``url``."""
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return json.loads(resp.text)
+
+
+def merge_mesh(mesh_path: Path, entries: List[Dict]) -> None:
+    """Merge ``entries`` into JSON mesh at ``mesh_path`` by archetype name."""
+    if mesh_path.exists():
+        data = json.loads(mesh_path.read_text())
+    else:
+        data = []
+    names = {e.get("name") for e in data}
+    for e in entries:
+        if e.get("name") not in names:
+            data.append(e)
+            names.add(e.get("name"))
+    mesh_path.write_text(json.dumps(data, indent=2))

--- a/tests/unit/test_core/test_reflection.py
+++ b/tests/unit/test_core/test_reflection.py
@@ -19,3 +19,24 @@ def test_spiral_hash_changes():
     log1 = ReflectionLog(state="a", spin="x")
     log2 = ReflectionLog(state="b", spin="x")
     assert log1.spiral_hash != log2.spiral_hash
+
+
+def test_to_markdown():
+    log = ReflectionLog()
+    log.log("note", ["spiral_flip"], mood="playful")
+    md = log.to_markdown()
+    assert md.startswith("-")
+
+
+def test_emit_mesh(monkeypatch):
+    log = ReflectionLog()
+    log.log("hello", ["spiral_flip"], mood="playful")
+
+    records = []
+
+    def fake(event_type, payload, phase=None, origin=None, verbose=False):
+        records.append((event_type, payload))
+
+    monkeypatch.setattr("tsal.core.mesh_logger.log_event", fake)
+    log.emit_mesh()
+    assert records and records[0][0] == "REFLECTION"

--- a/tests/unit/test_tools/test_archetype_fetcher.py
+++ b/tests/unit/test_tools/test_archetype_fetcher.py
@@ -1,0 +1,26 @@
+from tsal.tools.archetype_fetcher import fetch_online_mesh, merge_mesh
+import json
+from pathlib import Path
+
+class DummyResp:
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.status_code = 200
+    def raise_for_status(self):
+        pass
+
+
+def test_merge_mesh(tmp_path):
+    mesh = tmp_path / "mesh.json"
+    mesh.write_text(json.dumps([{"name": "A"}]))
+    merge_mesh(mesh, [{"name": "B"}])
+    data = json.loads(mesh.read_text())
+    assert any(e["name"] == "B" for e in data)
+
+
+def test_fetch_online_mesh(monkeypatch):
+    def fake_get(url):
+        return DummyResp('[{"name": "X"}]')
+    monkeypatch.setattr('tsal.tools.archetype_fetcher.requests.get', fake_get)
+    entries = fetch_online_mesh('http://example.com')
+    assert entries and entries[0]['name'] == 'X'


### PR DESCRIPTION
## Summary
- extend `ReflectionLog` with `to_markdown` and `emit_mesh`
- allow seedrunner to fetch remote archetype meshes
- expose fetcher in tools package
- add new `archetype_fetcher` module
- test fetcher and new reflection features

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846bfe669508329be02ca2d737ab992