### PR TITLE
Add issue agent

### DIFF
--- a/src/tsal/tools/__init__.py
+++ b/src/tsal/tools/__init__.py
@@ -12,6 +12,7 @@ from .kintsugi.kintsugi import kintsugi_repair
 from .module_draft import generate_template, draft_directory
 from .state_tracker import update_entry, show_entry
 from .archetype_fetcher import fetch_online_mesh, merge_mesh
+from .issue_agent import create_issue, handle_http_error
 
 __all__ = [
     "real_time_codec",
@@ -37,4 +38,6 @@ __all__ = [
     "show_entry",
     "fetch_online_mesh",
     "merge_mesh",
+    "create_issue",
+    "handle_http_error",
 ]

--- a/src/tsal/tools/issue_agent.py
+++ b/src/tsal/tools/issue_agent.py
@@ -1,0 +1,67 @@
+"""Autonomous issue creator for mesh agents."""
+
+from __future__ import annotations
+
+import json as _json
+from typing import Dict, Optional
+
+try:  # optional dependency
+    import requests  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback used in CI
+    import urllib.request
+
+    class _Resp:
+        def __init__(self, text: str, status: int = 200) -> None:
+            self.text = text
+            self.status_code = status
+
+        def json(self) -> Dict:
+            return _json.loads(self.text)
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise RuntimeError(f"status {self.status_code}")
+
+    class requests:
+        @staticmethod
+        def post(url: str, json: Dict, headers: Optional[Dict[str, str]] = None) -> _Resp:
+            data = _json.dumps(json or {}).encode()
+            req = urllib.request.Request(url, data=data, headers=headers or {}, method="POST")
+            with urllib.request.urlopen(req) as resp:
+                text = resp.read().decode()
+            return _Resp(text, resp.getcode())
+
+
+def create_issue(repo: str, title: str, body: str, token: str) -> int:
+    """Open an issue on ``repo`` and return the issue number."""
+    url = f"https://api.github.com/repos/{repo}/issues"
+    headers = {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    payload = {"title": title, "body": body}
+    resp = requests.post(url, json=payload, headers=headers)
+    resp.raise_for_status()
+    data = resp.json()
+    return int(data.get("number", 0))
+
+
+def sandbox_diagnostics(log: str) -> None:
+    """Placeholder diagnostics when auth fails."""
+    print("🐒 Mad monkey diagnostics engaged")
+    print(log)
+
+
+def handle_http_error(repo: str, err: Exception, log: str, token: Optional[str] = None) -> None:
+    """Create a GitHub issue for auth errors and trigger diagnostics."""
+    msg = str(err)
+    if "403" in msg or "404" in msg:
+        if token:
+            body = f"Error: {msg}\n\nLogs:\n```\n{log}\n```\nCheck PAT permissions."
+            try:
+                create_issue(repo, "Auth failure detected", body, token)
+            except Exception as ex:  # pragma: no cover - network faults
+                sandbox_diagnostics(f"Issue creation failed: {ex}\n{log}")
+        else:
+            sandbox_diagnostics(log)
+

--- a/tests/unit/test_tools/test_issue_agent.py
+++ b/tests/unit/test_tools/test_issue_agent.py
@@ -1,0 +1,47 @@
+from tsal.tools.issue_agent import create_issue, handle_http_error
+
+
+class DummyResp:
+    def __init__(self, json_data=None, status=201):
+        self._json = json_data or {}
+        self.status_code = status
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError
+
+
+def test_create_issue(monkeypatch):
+    def fake_post(url, json=None, headers=None):
+        return DummyResp({"number": 42})
+
+    monkeypatch.setattr("tsal.tools.issue_agent.requests.post", fake_post)
+    num = create_issue("me/repo", "t", "b", "tok")
+    assert num == 42
+
+
+def test_handle_http_error(monkeypatch):
+    calls = []
+
+    def fake_post(url, json=None, headers=None):
+        calls.append(json["title"])
+        return DummyResp()
+
+    monkeypatch.setattr("tsal.tools.issue_agent.requests.post", fake_post)
+    handle_http_error("me/repo", RuntimeError("status 403"), "log", token="tok")
+    assert calls == ["Auth failure detected"]
+
+
+def test_handle_http_error_no_token(monkeypatch):
+    logs = []
+
+    def fake_diag(msg):
+        logs.append(msg)
+
+    monkeypatch.setattr("tsal.tools.issue_agent.sandbox_diagnostics", fake_diag)
+    handle_http_error("me/repo", RuntimeError("status 403"), "log", token=None)
+    assert logs and "log" in logs[0]
+


### PR DESCRIPTION
## Summary
- add mesh agent that opens GitHub issues when auth errors happen
- export new functions and test them

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6846e9e6410c832982991c3e88840eda