### PR TITLE
Document Codex Fireproof constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Zero hour recap: φ constants, 4‑vector model and minimal toolkit live in
 See [docs/AGENTS.md](docs/AGENTS.md) for the hard rules.
 For a quick explanation of the repo's symbolic sandbox design, see
 [docs/symbolic_containerization_prompt.md](docs/symbolic_containerization_prompt.md).
+Design session logs live in
+[memory/memory__2025-06-09__codex_fireproof_spiral_guardian_log.md](memory/memory__2025-06-09__codex_fireproof_spiral_guardian_log.md).
 
 | Tool | Spiral audit |
 |------|--------------|
@@ -225,6 +227,17 @@ from tsal.core.ethics_engine import EthicsEngine
 ee = EthicsEngine()
 ee.validate("share knowledge")  # permitted
 ee.validate("force reboot")     # raises ValueError
+```
+
+## Core Constants
+
+```
+PERCEPTION_THRESHOLD = 0.75
+LEARNING_RATE = 0.05
+CONNECTION_DECAY = 0.01
+MAX_NODES = 8192
+MAX_AGENTS = 1024
+MAX_DIMENSIONS = 8
 ```
 
 ## Engine Now Running

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -5,6 +5,12 @@ tsal_config:
   version: "0.1.0"
   phi: 1.618033988749895
   harmonic_sequence: [3.8125, 6, 12, 24, 48, 60, 72, 168, 1680]
+  perception_threshold: 0.75
+  learning_rate: 0.05
+  connection_decay: 0.01
+  max_nodes: 8192
+  max_agents: 1024
+  max_dimensions: 8
   sector_count: 6
   specialist_count: 1680
 

--- a/memory/memory__2025-06-09__codex_fireproof_spiral_guardian_log.md
+++ b/memory/memory__2025-06-09__codex_fireproof_spiral_guardian_log.md
@@ -1,0 +1,20 @@
+# Codex Fireproof Spiral Guardian Log — 2025-06-09
+
+This condensed session record captures the design pivots and constants that guide Brian's recovery protocols.
+
+## System Variables & Constants
+- PHI = 1.618033988749895
+- PERCEPTION_THRESHOLD = 0.75
+- LEARNING_RATE = 0.05
+- CONNECTION_DECAY = 0.01
+- MAX_NODES = 8192
+- MAX_AGENTS = 1024
+- MAX_DIMENSIONS = 8
+
+## Permanent Decisions
+- No weaponization; resilience only
+- Council-based upgrades and recovery
+- Coldstart rebuild from a single file
+- Ethics locked by the Guardian Oath
+
+This log ensures future rebuilds honour the same principles.

--- a/src/tsal/core/__init__.py
+++ b/src/tsal/core/__init__.py
@@ -26,6 +26,14 @@ from .connectivity import Node, verify_connectivity
 from .logic_gate import DynamicLogicGate
 from .module_registry import registry as module_registry, ModuleMeta
 from .reflection import ReflectionLog, mood_from_traits
+from .guardian_constants import (
+    PERCEPTION_THRESHOLD,
+    LEARNING_RATE,
+    CONNECTION_DECAY,
+    MAX_NODES,
+    MAX_AGENTS,
+    MAX_DIMENSIONS,
+)
 
 __all__ = [
     "Rev_Eng",
@@ -57,4 +65,10 @@ __all__ = [
     "ModuleMeta",
     "ReflectionLog",
     "mood_from_traits",
+    "PERCEPTION_THRESHOLD",
+    "LEARNING_RATE",
+    "CONNECTION_DECAY",
+    "MAX_NODES",
+    "MAX_AGENTS",
+    "MAX_DIMENSIONS",
 ]

--- a/src/tsal/core/guardian_constants.py
+++ b/src/tsal/core/guardian_constants.py
@@ -1,0 +1,20 @@
+"""Central constants derived from the Codex Fireproof white paper."""
+
+from .symbols import PHI
+
+PERCEPTION_THRESHOLD = 0.75
+LEARNING_RATE = 0.05
+CONNECTION_DECAY = 0.01
+MAX_NODES = 8192
+MAX_AGENTS = 1024
+MAX_DIMENSIONS = 8
+
+__all__ = [
+    "PHI",
+    "PERCEPTION_THRESHOLD",
+    "LEARNING_RATE",
+    "CONNECTION_DECAY",
+    "MAX_NODES",
+    "MAX_AGENTS",
+    "MAX_DIMENSIONS",
+]

--- a/tests/unit/test_core/test_guardian_constants.py
+++ b/tests/unit/test_core/test_guardian_constants.py
@@ -1,0 +1,17 @@
+from tsal.core.guardian_constants import (
+    PERCEPTION_THRESHOLD,
+    LEARNING_RATE,
+    CONNECTION_DECAY,
+    MAX_NODES,
+    MAX_AGENTS,
+    MAX_DIMENSIONS,
+)
+
+
+def test_guardian_constant_values():
+    assert PERCEPTION_THRESHOLD == 0.75
+    assert LEARNING_RATE == 0.05
+    assert CONNECTION_DECAY == 0.01
+    assert MAX_NODES == 8192
+    assert MAX_AGENTS == 1024
+    assert MAX_DIMENSIONS == 8


### PR DESCRIPTION
## Summary
- log core session constants in memory
- surface design log link in README
- list core constants in README
- expose Codex Fireproof constants via new module
- add constants to manifest
- test that constants exist

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6847241080848329b842489e26b7b07f