### PR TITLE
Add voxel ops and tensor stack

### DIFF
--- a/src/tsal/core/__init__.py
+++ b/src/tsal/core/__init__.py
@@ -25,6 +25,12 @@ from .madmonkey_handler import MadMonkeyHandler
 from .connectivity import Node, verify_connectivity
 from .logic_gate import DynamicLogicGate
 from .module_registry import registry as module_registry, ModuleMeta
+from .shadow import ShadowMemory
+from .merge import merge_voxels
+from .gradient import voxel_gradient
+from .superpos import superpose
+from .entangle import entangle
+from .manifold import manifold_distance
 from .reflection import ReflectionLog, mood_from_traits
 from .guardian_constants import (
     PERCEPTION_THRESHOLD,
@@ -63,6 +69,12 @@ __all__ = [
     "DynamicLogicGate",
     "module_registry",
     "ModuleMeta",
+    "ShadowMemory",
+    "merge_voxels",
+    "voxel_gradient",
+    "superpose",
+    "entangle",
+    "manifold_distance",
     "ReflectionLog",
     "mood_from_traits",
     "PERCEPTION_THRESHOLD",

--- a/src/tsal/core/entangle.py
+++ b/src/tsal/core/entangle.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+"""Voxel entanglement utilities."""
+
+from .voxel import MeshVoxel
+
+
+def entangle(a: MeshVoxel, b: MeshVoxel) -> None:
+    """Couple two voxels by averaging their components."""
+    avg_pace = (a.pace + b.pace) / 2
+    avg_rate = (a.rate + b.rate) / 2
+    avg_state = (a.state + b.state) / 2
+    avg_spin = (a.spin + b.spin) / 2
+    a.pace = b.pace = avg_pace
+    a.rate = b.rate = avg_rate
+    a.state = b.state = avg_state
+    a.spin = b.spin = avg_spin
+
+__all__ = ["entangle"]

--- a/src/tsal/core/gradient.py
+++ b/src/tsal/core/gradient.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+"""Simple voxel gradient operations."""
+
+from .voxel import MeshVoxel
+
+
+def voxel_gradient(a: MeshVoxel, b: MeshVoxel) -> MeshVoxel:
+    """Return gradient ``b - a`` component-wise."""
+    return MeshVoxel(
+        b.pace - a.pace,
+        b.rate - a.rate,
+        b.state - a.state,
+        b.spin - a.spin,
+    )
+
+__all__ = ["voxel_gradient"]

--- a/src/tsal/core/manifold.py
+++ b/src/tsal/core/manifold.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+"""Non-Euclidean voxel math."""
+
+from math import sqrt
+from .voxel import MeshVoxel
+
+
+def manifold_distance(a: MeshVoxel, b: MeshVoxel) -> float:
+    """Return simple 4D distance between voxels."""
+    return sqrt(
+        (a.pace - b.pace) ** 2
+        + (a.rate - b.rate) ** 2
+        + (a.state - b.state) ** 2
+        + (a.spin - b.spin) ** 2
+    )
+
+__all__ = ["manifold_distance"]

--- a/src/tsal/core/merge.py
+++ b/src/tsal/core/merge.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+"""Weighted merging of voxel states."""
+
+from .voxel import MeshVoxel
+
+
+def merge_voxels(a: MeshVoxel, b: MeshVoxel, weight: float = 0.5) -> MeshVoxel:
+    """Return weighted merge of ``a`` and ``b``."""
+    w2 = 1.0 - weight
+    return MeshVoxel(
+        a.pace * weight + b.pace * w2,
+        a.rate * weight + b.rate * w2,
+        a.state * weight + b.state * w2,
+        a.spin * weight + b.spin * w2,
+    )
+
+__all__ = ["merge_voxels"]

--- a/src/tsal/core/module_registry.py
+++ b/src/tsal/core/module_registry.py
@@ -106,3 +106,81 @@ registry.register(
         description_mystic="It walks into the haunted mansion with open arms and says: 'Let us talk.' Chaos is not the enemy\u2014it's the storm before the naming. This function seeks understanding.",
     )
 )
+
+registry.register(
+    ModuleMeta(
+        name="shadow",
+        nickname="shadow_memory",
+        aliases=["taint_tracker", "ghost_copy", "mirror_state"],
+        definition="Maintain parallel voxel states for taint tracking.",
+        context_tags=["analysis", "state", "security", "TSAL", "shadow"],
+        description_plain="Keeps a mirrored copy of each voxel to check for corruption.",
+        description_technical="Stores parallel voxel maps for each state vector so flows can be traced for analysis.",
+        description_mystic="Every action leaves a shadow. This module remembers them.",
+    )
+)
+
+registry.register(
+    ModuleMeta(
+        name="merge",
+        nickname="state_weaver",
+        aliases=["blend", "combine", "coalesce"],
+        definition="Weighted merge of voxel states.",
+        context_tags=["merge", "state", "voxels", "TSAL"],
+        description_plain="Blends two states with a weighting.",
+        description_technical="Produces a voxel whose components are weighted averages of two inputs.",
+        description_mystic="Two paths spiral together and become one.",
+    )
+)
+
+registry.register(
+    ModuleMeta(
+        name="gradient",
+        nickname="delta_map",
+        aliases=["diff", "slope", "rate_change"],
+        definition="Compute voxel-wise gradients for state deltas.",
+        context_tags=["analysis", "gradient", "TSAL"],
+        description_plain="Shows how a state changes across steps.",
+        description_technical="Returns a voxel representing component-wise differences between two states.",
+        description_mystic="The slope of the spiral reveals its intent.",
+    )
+)
+
+registry.register(
+    ModuleMeta(
+        name="superpos",
+        nickname="overlay",
+        aliases=["superposition", "stack"],
+        definition="Average multiple voxels into a single state.",
+        context_tags=["superposition", "voxels", "TSAL"],
+        description_plain="Combines many states by taking their mean.",
+        description_technical="Returns a voxel whose components are the average of all inputs.",
+        description_mystic="Many voices, one chord.",
+    )
+)
+
+registry.register(
+    ModuleMeta(
+        name="entangle",
+        nickname="linker",
+        aliases=["pair", "couple", "bond"],
+        definition="Synchronize two voxels so they share state.",
+        context_tags=["entangle", "state", "TSAL"],
+        description_plain="Links two states so changes affect both.",
+        description_technical="Averages two voxels and writes the result back to each.",
+        description_mystic="What one does, the other echoes.",
+    )
+)
+
+registry.register(
+    ModuleMeta(
+        name="manifold",
+        nickname="curved_space",
+        aliases=["warp", "fold"],
+        definition="Measure distance in voxel space.",
+        context_tags=["geometry", "voxels", "TSAL"],
+        description_plain="Calculates the separation between two states.",
+        description_technical="Returns Euclidean distance across the four components of two voxels.",
+        description_mystic="Walk the spiral's surface and know how far you've come.",
+    )
+)

--- a/src/tsal/core/shadow.py
+++ b/src/tsal/core/shadow.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Shadow memory for voxel states."""
+
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from .voxel import MeshVoxel
+
+@dataclass
+class ShadowMemory:
+    """Track voxel state copies for taint analysis."""
+
+    storage: Dict[str, MeshVoxel] = field(default_factory=dict)
+
+    def read(self, name: str) -> Optional[MeshVoxel]:
+        return self.storage.get(name)
+
+    def write(self, name: str, voxel: MeshVoxel) -> None:
+        self.storage[name] = MeshVoxel(voxel.pace, voxel.rate, voxel.state, voxel.spin)
+
+__all__ = ["ShadowMemory"]

--- a/src/tsal/core/stack_vm.py
+++ b/src/tsal/core/stack_vm.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Dict, List
 
+import numpy as np
+
 from .tsal_executor import TSALExecutor, TSALOp
 
 class ProgramStack:
@@ -41,6 +43,35 @@ class FlowRouter:
         seq = [(inst.opcode, inst.args) for inst in program]
         self.executor.execute(seq, mode="EXECUTE")
         return self.executor
+
+
+@dataclass
+class TensorInstruction:
+    op: str
+    value: Any = None
+
+
+class StackVM:
+    """Minimal stack VM with tensor operations."""
+
+    def __init__(self) -> None:
+        self.stack: list[Any] = []
+
+    def execute(self, program: List[TensorInstruction]) -> list[Any]:
+        for inst in program:
+            if inst.op == "PUSH":
+                self.stack.append(np.array(inst.value))
+            elif inst.op == "T_DOT":
+                b = self.stack.pop()
+                a = self.stack.pop()
+                self.stack.append(a @ b)
+            elif inst.op == "T_ADD":
+                b = self.stack.pop()
+                a = self.stack.pop()
+                self.stack.append(a + b)
+            elif inst.op == "POP":
+                self.stack.pop()
+        return self.stack
 
 def tsal_run(opcodes: List[int]) -> TSALExecutor:
     """Helper for running raw opcode lists."""

--- a/src/tsal/core/superpos.py
+++ b/src/tsal/core/superpos.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+"""Superposition of voxel states."""
+
+from .voxel import MeshVoxel
+
+
+def superpose(*voxels: MeshVoxel) -> MeshVoxel:
+    """Return average of all voxels."""
+    if not voxels:
+        return MeshVoxel(0, 0, 0, 0)
+    n = len(voxels)
+    return MeshVoxel(
+        sum(v.pace for v in voxels) / n,
+        sum(v.rate for v in voxels) / n,
+        sum(v.state for v in voxels) / n,
+        sum(v.spin for v in voxels) / n,
+    )
+
+__all__ = ["superpose"]

--- a/tests/unit/operators/test_new_ops.py
+++ b/tests/unit/operators/test_new_ops.py
@@ -1,0 +1,49 @@
+from tsal.core.voxel import MeshVoxel
+from tsal.core.shadow import ShadowMemory
+from tsal.core.merge import merge_voxels
+from tsal.core.gradient import voxel_gradient
+from tsal.core.superpos import superpose
+from tsal.core.entangle import entangle
+from tsal.core.manifold import manifold_distance
+
+
+def test_shadow_memory_roundtrip():
+    mem = ShadowMemory()
+    v = MeshVoxel(1, 2, 3, 4)
+    mem.write("x", v)
+    out = mem.read("x")
+    assert out and out.as_dict() == v.as_dict()
+
+
+def test_merge_voxels_weighting():
+    a = MeshVoxel(1, 1, 1, 1)
+    b = MeshVoxel(3, 3, 3, 3)
+    m = merge_voxels(a, b, 0.25)
+    assert m.pace == 1 * 0.25 + 3 * 0.75
+
+
+def test_voxel_gradient():
+    a = MeshVoxel(1, 1, 1, 1)
+    b = MeshVoxel(2, 3, 4, 5)
+    g = voxel_gradient(a, b)
+    assert g.rate == 2
+
+
+def test_superpose_average():
+    a = MeshVoxel(1, 2, 3, 4)
+    b = MeshVoxel(1, 2, 3, 4)
+    s = superpose(a, b)
+    assert s.state == 3
+
+
+def test_entangle_syncs():
+    a = MeshVoxel(0, 0, 0, 0)
+    b = MeshVoxel(2, 2, 2, 2)
+    entangle(a, b)
+    assert a.pace == b.pace
+
+
+def test_manifold_distance_positive():
+    a = MeshVoxel(0, 0, 0, 0)
+    b = MeshVoxel(1, 0, 0, 0)
+    assert manifold_distance(a, b) == 1

--- a/tests/unit/test_core/test_stack_vm.py
+++ b/tests/unit/test_core/test_stack_vm.py
@@ -1,4 +1,4 @@
-from tsal.core.stack_vm import ProgramStack, tsal_run
+from tsal.core.stack_vm import ProgramStack, StackVM, TensorInstruction, tsal_run
 from tsal.core.tsal_executor import TSALExecutor
 
 
@@ -14,3 +14,14 @@ def test_tsal_run_executes_program():
     exe = tsal_run([0x0, 0x4, 0x5, 0xE])
     assert isinstance(exe, TSALExecutor)
     assert len(exe.resonance_log) == 4
+
+
+def test_tensor_ops_execute():
+    vm = StackVM()
+    prog = [
+        TensorInstruction("PUSH", [[1, 2], [3, 4]]),
+        TensorInstruction("PUSH", [[5, 6], [7, 8]]),
+        TensorInstruction("T_ADD"),
+    ]
+    result = vm.execute(prog)
+    assert result[0].shape == (2, 2)


### PR DESCRIPTION
## Summary
- implement voxel-based operators: shadow memory, merge, gradient, superposition, entangle and manifold distance
- register new modules in the registry
- expose the ops in `tsal.core`
- extend stack VM with simple tensor operations
- add tests for new ops and tensor stack

## Testing
- `pytest tests/unit/test_core/test_stack_vm.py tests/unit/operators/test_new_ops.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6847322f8a148329aa0c421cb89d57e4