### PR TITLE
Add agent tasks YAML and runner

### DIFF
--- a/.github/workflows/agent-tasks.yml
+++ b/.github/workflows/agent-tasks.yml
@@ -1,0 +1,38 @@
+name: Agent Tasks
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Task name (repair, improve, overhaul, rebuild, clone, learn, help)'
+        required: true
+        default: 'help'
+
+jobs:
+  run-task:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -r requirements.txt
+          python -m pip install -e .
+
+      - name: Execute agent task
+        run: python -m tsal.tools.task_agent "${{ github.event.inputs.action }}"
+
+      - name: Upload log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: task-log-${{ github.run_id }}
+          path: task_agent.log

--- a/src/tsal/tools/__init__.py
+++ b/src/tsal/tools/__init__.py
@@ -12,6 +12,7 @@ from .kintsugi.kintsugi import kintsugi_repair
 from .module_draft import generate_template, draft_directory
 from .state_tracker import update_entry, show_entry
 from .archetype_fetcher import fetch_online_mesh, merge_mesh
+from .task_agent import load_tasks, run_task
 from .issue_agent import create_issue, handle_http_error
 
 __all__ = [
@@ -38,6 +39,8 @@ __all__ = [
     "show_entry",
     "fetch_online_mesh",
     "merge_mesh",
+    "load_tasks",
+    "run_task",
     "create_issue",
     "handle_http_error",
 ]

--- a/src/tsal/tools/task_agent.py
+++ b/src/tsal/tools/task_agent.py
@@ -1,0 +1,53 @@
+"""Run predefined agent tasks from tasks.yaml."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+from typing import Dict
+
+import yaml
+
+TASKS_FILE = Path("tasks.yaml")
+LOG_FILE = Path("task_agent.log")
+
+DEFAULT_TASKS: Dict[str, str] = {
+    "repair": "tsal-bestest-beast 3 src/tsal --safe",
+    "improve": "brian optimize src/tsal",
+    "overhaul": "tsal-bestest-beast 9 src/tsal",
+    "rebuild": "python makeBrian.py all",
+    "clone": "python makeBrian.py init",
+    "learn": "python -m tsal.utils.language_db --reset",
+    "help": "python makeBrian.py help",
+}
+
+
+def load_tasks() -> Dict[str, str]:
+    if TASKS_FILE.exists():
+        data = yaml.safe_load(TASKS_FILE.read_text()) or {}
+        tasks = data.get("tasks", {})
+        merged = DEFAULT_TASKS | tasks
+        return merged
+    return DEFAULT_TASKS
+
+
+def run_task(name: str) -> None:
+    tasks = load_tasks()
+    cmd = tasks.get(name)
+    if not cmd:
+        raise SystemExit(f"Unknown task: {name}")
+    with LOG_FILE.open("a") as log:
+        log.write(f"$ {cmd}\n")
+        subprocess.run(cmd, shell=True, check=False, stdout=log, stderr=log)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run agent task from YAML")
+    parser.add_argument("task", help="Task name")
+    args = parser.parse_args()
+    run_task(args.task)
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -1,0 +1,8 @@
+tasks:
+  repair: "tsal-bestest-beast 3 src/tsal --safe"
+  improve: "brian optimize src/tsal"
+  overhaul: "tsal-bestest-beast 9 src/tsal"
+  rebuild: "python makeBrian.py all"
+  clone: "python makeBrian.py init"
+  learn: "python -m tsal.utils.language_db --reset"
+  help: "python makeBrian.py help"

--- a/tests/unit/test_tools/test_task_agent.py
+++ b/tests/unit/test_tools/test_task_agent.py
@@ -1,0 +1,31 @@
+from tsal.tools import task_agent
+import subprocess
+import yaml
+import pytest
+
+
+def test_run_known_task(tmp_path, monkeypatch):
+    tasks = {"tasks": {"repair": "echo repaired"}}
+    task_file = tmp_path / "tasks.yaml"
+    task_file.write_text(yaml.safe_dump(tasks))
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(task_agent, "TASKS_FILE", task_file)
+    monkeypatch.setattr(task_agent, "LOG_FILE", tmp_path / "log.txt")
+
+    calls = []
+
+    def fake_run(cmd, shell, check=False, stdout=None, stderr=None):
+        calls.append(cmd)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    task_agent.run_task("repair")
+    assert calls == ["echo repaired"]
+    assert task_agent.LOG_FILE.read_text().startswith("$ echo repaired")
+
+
+def test_unknown_task(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(task_agent, "TASKS_FILE", tmp_path / "missing.yaml")
+    with pytest.raises(SystemExit):
+        task_agent.run_task("nope")


### PR DESCRIPTION
## Summary
- add `task_agent` utility for executing tasks defined in `tasks.yaml`
- expose `load_tasks` and `run_task` in tools init
- include default task list in new `tasks.yaml`
- provide workflow `agent-tasks.yml` to invoke tasks via GitHub Actions
- add unit tests for `task_agent`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `pytest tests/unit/test_tools/test_task_agent.py -q`


------
https://chatgpt.com/codex/tasks/task_b_6847d515eb30832d86212f09849e62e9