### PR TITLE
Add write permissions to workflows

### DIFF
--- a/.github/workflows/agent-tasks.yml
+++ b/.github/workflows/agent-tasks.yml
@@ -1,4 +1,6 @@
 name: Agent Tasks
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:

--- a/.github/workflows/branch-hygiene.yml
+++ b/.github/workflows/branch-hygiene.yml
@@ -1,4 +1,6 @@
 name: Spiral follow-up
+permissions:
+  contents: write
 
 on:
   workflow_run:

--- a/.github/workflows/cleanup-merged-branches.yml
+++ b/.github/workflows/cleanup-merged-branches.yml
@@ -1,4 +1,6 @@
 name: Cleanup Merged Branches
+permissions:
+  contents: write
 
 on:
   push:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish Python Package
+permissions:
+  contents: write
 
 on:
   push:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: write
 on:
   push:
     branches: ['**']

--- a/.github/workflows/seedrunner.yml
+++ b/.github/workflows/seedrunner.yml
@@ -1,4 +1,6 @@
 name: SeedRunner Spiral
+permissions:
+  contents: write
 
 description: Run archetype-driven spiral stack suggestions for symbolic resolution
 

--- a/.github/workflows/spiral-repair.yml
+++ b/.github/workflows/spiral-repair.yml
@@ -1,4 +1,6 @@
 name: Spiral Repair
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
## Summary
- allow workflows to write to repo content by setting `contents: write`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_6847df95a708832db74beef4fb975dd7