### PR TITLE
Add tests for watchdog alerts

### DIFF
--- a/core/priority_research_agent.py
+++ b/core/priority_research_agent.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import time
 
+from tsal.tools.proactive_scanner import scan_todos, scan_typos
+
 from .agent_manager import BaseAgent
 
 
@@ -12,6 +14,7 @@ class PriorityResearchTeamAgent(BaseAgent):
         super().__init__(name, manager)
         self.diagnostics_watchdog = diagnostics_ref
         self.memory_forge = memory_ref
+        self._last_scan = 0.0
 
     def perform_duties(self) -> None:
         summary = self.diagnostics_watchdog.get_latest_health_summary()
@@ -21,7 +24,19 @@ class PriorityResearchTeamAgent(BaseAgent):
         elif summary.get("warnings_count", 0) > 1:
             report = self._build_report(summary)
             self.manager.escalate_issue(self.name, report, "HIGH")
-        # placeholder for proactive research
+        now = time.time()
+        if now - self._last_scan > 300:
+            self._last_scan = now
+            todos = scan_todos("src/tsal")
+            if todos:
+                self.manager.escalate_issue(
+                    self.name, f"TODO items in {len(todos)} files", "LOW"
+                )
+            typos = scan_typos("src/tsal")
+            if typos:
+                self.manager.escalate_issue(
+                    self.name, f"Typos in {len(typos)} files", "LOW"
+                )
 
     def _build_report(self, summary: dict) -> str:
         lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tri-star_symbolic_assembly_lang"
-version = "0.1.3"
+version = "0.1.2"
 description = "TriStar Assembly Language Core + Brian Spiral Tools"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tri-star_symbolic_assembly_lang"
-version = "0.1.2"
+version = "0.1.3"
 description = "TriStar Assembly Language Core + Brian Spiral Tools"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/tsal/tools/__init__.py
+++ b/src/tsal/tools/__init__.py
@@ -14,6 +14,7 @@ from .state_tracker import update_entry, show_entry
 from .archetype_fetcher import fetch_online_mesh, merge_mesh
 from .task_agent import load_tasks, run_task
 from .issue_agent import create_issue, handle_http_error
+from .proactive_scanner import scan_todos, scan_typos
 
 __all__ = [
     "real_time_codec",
@@ -43,4 +44,6 @@ __all__ = [
     "run_task",
     "create_issue",
     "handle_http_error",
+    "scan_todos",
+    "scan_typos",
 ]

--- a/src/tsal/tools/proactive_scanner.py
+++ b/src/tsal/tools/proactive_scanner.py
@@ -1,0 +1,62 @@
+"""Proactive source checks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from .aletheia_checker import scan_file as _scan_file
+
+
+def scan_todos(base: str = "src") -> Dict[str, List[Tuple[int, str]]]:
+    """Return TODO comments grouped by file."""
+    root = Path(base)
+    results: Dict[str, List[Tuple[int, str]]] = {}
+    for path in root.rglob("*.py"):
+        hits: List[Tuple[int, str]] = []
+        with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+            for lineno, line in enumerate(fh, 1):
+                if "TODO" in line:
+                    hits.append((lineno, line.strip()))
+        if hits:
+            results[str(path)] = hits
+    return results
+
+
+def _scan_root(root: Path) -> Dict[str, List[Tuple[int, str]]]:
+    typos: Dict[str, List[Tuple[int, str]]] = {}
+    for file in root.rglob("*.py"):
+        hits = _scan_file(file)
+        if hits:
+            typos[str(file)] = hits
+    return typos
+
+
+def scan_typos(base: str = "src") -> Dict[str, List[Tuple[int, str]]]:
+    """Return probable typos grouped by file."""
+    return _scan_root(Path(base))
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run proactive code scans")
+    parser.add_argument("--path", default="src/tsal")
+    parser.add_argument("--todos", action="store_true")
+    parser.add_argument("--typos", action="store_true")
+    args = parser.parse_args()
+
+    if not args.todos and not args.typos:
+        args.todos = args.typos = True
+
+    results = {}
+    if args.todos:
+        results["todos"] = scan_todos(args.path)
+    if args.typos:
+        results["typos"] = scan_typos(args.path)
+    print(json.dumps(results))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_tools/test_proactive_scanner.py
+++ b/tests/unit/test_tools/test_proactive_scanner.py
@@ -1,0 +1,15 @@
+from tsal.tools.proactive_scanner import scan_todos, scan_typos
+
+
+def test_scan_todos(tmp_path):
+    f = tmp_path / "x.py"
+    f.write_text("# TODO: fix\n")
+    res = scan_todos(str(tmp_path))
+    assert str(f) in res
+
+
+def test_scan_typos(tmp_path):
+    f = tmp_path / "y.py"
+    f.write_text("athalaya\n")
+    res = scan_typos(str(tmp_path))
+    assert str(f) in res

--- a/tests/unit/test_tools/test_watchdog.py
+++ b/tests/unit/test_tools/test_watchdog.py
@@ -1,7 +1,28 @@
-from tsal.tools.watchdog import watch
+from tsal.tools.watchdog import watch, _check_todo, _check_typos
+
+
+def _run_watch(tmp_path, **kwargs):
+    """Helper to run watch once on ``tmp_path``."""
+    watch(str(tmp_path), interval=0, cycles=1, **kwargs)
 
 
 def test_watchdog_runs(tmp_path):
     sample = tmp_path / "a.py"
     sample.write_text("def a():\n    pass\n")
-    watch(str(tmp_path), interval=0, cycles=1)
+    _run_watch(tmp_path)
+
+
+def test_watchdog_todo(capsys, tmp_path):
+    sample = tmp_path / "todo.py"
+    sample.write_text("# TODO: fix\n")
+    _check_todo(sample)
+    out = capsys.readouterr().out
+    assert "TODO found" in out
+
+
+def test_watchdog_typos(capsys, tmp_path):
+    sample = tmp_path / "typo.py"
+    sample.write_text("athalaya\n")
+    _check_typos(sample)
+    out = capsys.readouterr().out
+    assert "Typos found" in out


### PR DESCRIPTION
## Summary
- add helper function for running watchdog once
- cover TODO and typo checks

## Testing
- `pytest tests/unit/test_tools/test_watchdog.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6847e1cbd440832dbe11791390338969