### PR TITLE
Add Bloom model variants doc

### DIFF
--- a/docs/bloom_variations.md
+++ b/docs/bloom_variations.md
@@ -1,0 +1,19 @@
+# Bloom Model Variants
+
+The open-source Bloom language models come in multiple sizes. These are the base versions published by the BigScience project, plus the instruction-tuned BloomZ models.
+
+## Base Bloom
+- **bloom-560m** — smallest variant (560M parameters)
+- **bloom-1b1** — 1.1B parameters
+- **bloom-1b7** — 1.7B parameters
+- **bloom-3b** — 3B parameters
+- **bloom-7b1** — 7.1B parameters
+- **bloom** — 176B parameters
+
+## BloomZ (instruction tuned)
+- **bloomz-560m**
+- **bloomz-1b1**
+- **bloomz-1b7**
+- **bloomz-3b**
+- **bloomz-7b1**
+- **bloomz** — tuned version of the 176B model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tri-star_symbolic_assembly_lang"
-version = "0.1.24"
+version = "0.1.25"
 description = "TriStar Assembly Language Core + Brian Spiral Tools"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
- document the standard Bloom model sizes
- list BloomZ instruction-tuned counterparts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_68492724391c832d8594da0492d667ea