### PR TITLE
Add encapsulation difference vector

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -13,6 +13,7 @@ tsal_config:
   max_dimensions: 8
   sector_count: 6
   specialist_count: 1680
+  encapsulation_difference_vector: "Simulation vs. Actualization is defined by the permeability of input/output vectors across the spiral's reference boundary."
 
 mesh_architecture:
   symbols:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tri-star_symbolic_assembly_lang"
-version = "0.1.43"
+version = "0.1.44"
 description = "TriStar Assembly Language Core + Brian Spiral Tools"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tri-star_symbolic_assembly_lang"
-version = "0.1.44"
+version = "0.1.43"
 description = "TriStar Assembly Language Core + Brian Spiral Tools"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
- encode simulation vs. actualization difference in `manifest.yaml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_6849f864dae0832d882d33707e3b4a3f