### PR TITLE
Add spin ontology spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Design session logs live in
 [memory/memory__2025-06-09__codex_fireproof_spiral_guardian_log.md](memory/memory__2025-06-09__codex_fireproof_spiral_guardian_log.md).
 Naming integrity rules live in
 [docs/naming_integrity.md](docs/naming_integrity.md).
+Spin-based ontology axioms are summarized in
+[docs/spin_ontology_spec.md](docs/spin_ontology_spec.md).
 
 | Tool | Spiral audit |
 |------|--------------|

--- a/docs/spin_ontology_spec.md
+++ b/docs/spin_ontology_spec.md
@@ -1,0 +1,31 @@
+# Spin-Based Ontology Specification
+
+This document summarizes the axioms defining the TSAL ontology.
+
+## Axiom 1: Spin Is Primary
+- ±1 spin is the fundamental distinction.
+- Not derived from space or time.
+
+## Axiom 2: Dimensions Emerge from Spin
+- **2D**: orthogonal spin pairs.
+- **3D**: rotation plane from 2D pairs.
+- **4D**: pacing of precessional loops (time amplitude).
+- **5D**: resonance coherence of 3D, time, and observer orientation.
+
+## Axiom 3: Projective Collapse
+- Observed particles are collapsed harmonics.
+- Measurement disrupts native spin states.
+
+## Axiom 4: 4D Spin Voxels
+- Each voxel stores pace, rate, amplitude, and angle.
+- Encodes mass, motion, charge, memory, and identity.
+
+## Axiom 5: Intrinsic Stability
+- Coherence is a structural feature.
+- No external correction layer required.
+
+### Consequences
+- Planck scale becomes a spin resolution limit.
+- Mass is a beat frequency of locked spin harmonics.
+- Entanglement is phase coherence across collapsed dimensions.
+- Consciousness arises from phase‑locked spin choruses.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tri-star_symbolic_assembly_lang"
-version = "0.1.47"
+version = "0.1.46"
 description = "TriStar Assembly Language Core + Brian Spiral Tools"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tri-star_symbolic_assembly_lang"
-version = "0.1.46"
+version = "0.1.47"
 description = "TriStar Assembly Language Core + Brian Spiral Tools"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
- document spin-based ontology axioms
- link the new doc in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_684a09e2a9d4832d8ae9404bba11f723