### PR TITLE
Implement meta-coherence and spin algebra modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tri-star_symbolic_assembly_lang"
-version = "0.1.63"
+version = "0.1.64"
 description = "TriStar Assembly Language Core + Brian Spiral Tools"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/tsal/__init__.py
+++ b/src/tsal/__init__.py
@@ -39,6 +39,8 @@ from .tools.spiral_audit import audit_path
 from .tools.reflect import reflect
 from .core.constants import AXIS_ZERO, ensure_spin_axis, UndefinedPhaseError
 from .core.oaths import GUARDIAN_OATH, ARC_REACTOR_BOOT_OATH
+from .core.meta_coherence import SpiralSignature, compute_spiral_signature
+from .core.spin_algebra import SpinState, SpinInteraction, combine_spins
 
 PHI = 1.618033988749895
 PHI_INV = 0.618033988749895
@@ -98,4 +100,9 @@ __all__ = [
     "UndefinedPhaseError",
     "GUARDIAN_OATH",
     "ARC_REACTOR_BOOT_OATH",
+    "SpiralSignature",
+    "compute_spiral_signature",
+    "SpinState",
+    "SpinInteraction",
+    "combine_spins",
 ]

--- a/src/tsal/core/__init__.py
+++ b/src/tsal/core/__init__.py
@@ -32,6 +32,8 @@ from .superpos import superpose
 from .entangle import entangle
 from .manifold import manifold_distance
 from .reflection import ReflectionLog, mood_from_traits
+from .meta_coherence import SpiralSignature, compute_spiral_signature
+from .spin_algebra import SpinState, SpinInteraction, combine_spins
 from .guardian_constants import (
     PERCEPTION_THRESHOLD,
     LEARNING_RATE,
@@ -83,4 +85,9 @@ __all__ = [
     "MAX_NODES",
     "MAX_AGENTS",
     "MAX_DIMENSIONS",
+    "SpiralSignature",
+    "compute_spiral_signature",
+    "SpinState",
+    "SpinInteraction",
+    "combine_spins",
 ]

--- a/src/tsal/core/meta_coherence.py
+++ b/src/tsal/core/meta_coherence.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+"""Simple meta-coherence calculation utilities."""
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+from .symbols import PHI
+
+
+@dataclass
+class SpiralSignature:
+    """Fourier-based spiral signature."""
+
+    amplitude: np.ndarray
+    phase: np.ndarray
+
+
+def compute_spiral_signature(phases: Sequence[float], golden_ratio: float = PHI) -> SpiralSignature:
+    """Return a basic spiral signature chart from raw phase data."""
+    arr = np.asarray(phases, dtype=float)
+    freq = np.fft.fft(arr)
+    modulated = freq * golden_ratio
+    amplitude = np.abs(modulated)
+    phase = np.angle(modulated)
+    return SpiralSignature(amplitude=amplitude, phase=phase)
+
+__all__ = ["SpiralSignature", "compute_spiral_signature"]

--- a/src/tsal/core/spin_algebra.py
+++ b/src/tsal/core/spin_algebra.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Minimal spin algebra for symbolic interactions."""
+
+from enum import Enum
+from dataclasses import dataclass
+from typing import Tuple
+
+
+class SpinState(Enum):
+    CURIOSITY = "curiosity"
+    DUTY = "duty"
+    DELIGHT = "delight"
+    INQUIRY = "inquiry"
+
+
+@dataclass
+class SpinInteraction:
+    """Resulting state of combining two spins."""
+
+    left: SpinState
+    right: SpinState
+    result: SpinState
+
+
+def combine_spins(a: SpinState, b: SpinState) -> SpinInteraction:
+    """Return deterministic result for simple spin combinations."""
+    table = {
+        (SpinState.CURIOSITY, SpinState.DUTY): SpinState.INQUIRY,
+        (SpinState.DUTY, SpinState.CURIOSITY): SpinState.INQUIRY,
+        (SpinState.CURIOSITY, SpinState.DELIGHT): SpinState.DELIGHT,
+    }
+    result = table.get((a, b), a)
+    return SpinInteraction(left=a, right=b, result=result)
+
+__all__ = ["SpinState", "SpinInteraction", "combine_spins"]

--- a/tests/unit/test_core/test_meta_coherence.py
+++ b/tests/unit/test_core/test_meta_coherence.py
@@ -1,0 +1,13 @@
+from tsal.core.meta_coherence import compute_spiral_signature
+import numpy as np
+
+
+def test_compute_spiral_signature_shape():
+    sig = compute_spiral_signature([0.0, 1.0, 0.5])
+    assert sig.amplitude.shape == sig.phase.shape
+    assert sig.amplitude.size == 3
+
+
+def test_compute_spiral_signature_values():
+    sig = compute_spiral_signature([0, 0, 0])
+    assert np.allclose(sig.amplitude, 0)

--- a/tests/unit/test_core/test_spin_algebra.py
+++ b/tests/unit/test_core/test_spin_algebra.py
@@ -1,0 +1,11 @@
+from tsal.core.spin_algebra import SpinState, combine_spins
+
+
+def test_combine_spins_inquiry():
+    interaction = combine_spins(SpinState.CURIOSITY, SpinState.DUTY)
+    assert interaction.result is SpinState.INQUIRY
+
+
+def test_combine_spins_default():
+    interaction = combine_spins(SpinState.DELIGHT, SpinState.DELIGHT)
+    assert interaction.result is SpinState.DELIGHT


### PR DESCRIPTION
## Summary
- add `meta_coherence` for Fourier-based spiral signature
- add `spin_algebra` with minimal spin combination logic
- expose new utilities in `tsal` package
- add unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684ac867123c832d890fe973cd997ba2