### PR TITLE
Improve proactive scanner integration

### DIFF
--- a/src/tsal/tools/__init__.py
+++ b/src/tsal/tools/__init__.py
@@ -14,7 +14,12 @@ from .state_tracker import update_entry, show_entry
 from .archetype_fetcher import fetch_online_mesh, merge_mesh
 from .task_agent import load_tasks, run_task
 from .issue_agent import create_issue, handle_http_error
-from .proactive_scanner import scan_todos, scan_typos
+from .proactive_scanner import (
+    scan_todos,
+    scan_typos,
+    scan_todo_file,
+    scan_typos_file,
+)
 
 __all__ = [
     "real_time_codec",
@@ -46,4 +51,6 @@ __all__ = [
     "handle_http_error",
     "scan_todos",
     "scan_typos",
+    "scan_todo_file",
+    "scan_typos_file",
 ]

--- a/src/tsal/tools/proactive_scanner.py
+++ b/src/tsal/tools/proactive_scanner.py
@@ -9,16 +9,28 @@ from typing import Dict, List, Tuple
 from .aletheia_checker import scan_file as _scan_file
 
 
+def scan_todo_file(path: str | Path) -> List[Tuple[int, str]]:
+    """Return TODO lines from ``path``."""
+    file = Path(path)
+    hits: List[Tuple[int, str]] = []
+    with open(file, "r", encoding="utf-8", errors="ignore") as fh:
+        for lineno, line in enumerate(fh, 1):
+            if "TODO" in line:
+                hits.append((lineno, line.strip()))
+    return hits
+
+
+def scan_typos_file(path: str | Path) -> List[Tuple[int, str]]:
+    """Return probable typos from ``path``."""
+    return _scan_file(Path(path))
+
+
 def scan_todos(base: str = "src") -> Dict[str, List[Tuple[int, str]]]:
     """Return TODO comments grouped by file."""
     root = Path(base)
     results: Dict[str, List[Tuple[int, str]]] = {}
     for path in root.rglob("*.py"):
-        hits: List[Tuple[int, str]] = []
-        with open(path, "r", encoding="utf-8", errors="ignore") as fh:
-            for lineno, line in enumerate(fh, 1):
-                if "TODO" in line:
-                    hits.append((lineno, line.strip()))
+        hits = scan_todo_file(path)
         if hits:
             results[str(path)] = hits
     return results
@@ -27,7 +39,7 @@ def scan_todos(base: str = "src") -> Dict[str, List[Tuple[int, str]]]:
 def _scan_root(root: Path) -> Dict[str, List[Tuple[int, str]]]:
     typos: Dict[str, List[Tuple[int, str]]] = {}
     for file in root.rglob("*.py"):
-        hits = _scan_file(file)
+        hits = scan_typos_file(file)
         if hits:
             typos[str(file)] = hits
     return typos

--- a/src/tsal/tools/watchdog.py
+++ b/src/tsal/tools/watchdog.py
@@ -7,17 +7,17 @@ import time
 from pathlib import Path
 
 from tsal.tools.brian import analyze_and_repair
-from tsal.tools.aletheia_checker import scan_file as _scan_file
+from tsal.tools.proactive_scanner import scan_todo_file, scan_typos_file
 
 
 def _check_todo(path: Path) -> None:
-    text = path.read_text(encoding="utf-8", errors="ignore")
-    if "TODO" in text:
+    hits = scan_todo_file(path)
+    if hits:
         print(f"[Watchdog] TODO found in {path}")
 
 
 def _check_typos(path: Path) -> None:
-    hits = _scan_file(path)
+    hits = scan_typos_file(path)
     if hits:
         print(f"[Watchdog] Typos found in {path}: {len(hits)}")
 

--- a/tests/unit/test_tools/test_proactive_scanner.py
+++ b/tests/unit/test_tools/test_proactive_scanner.py
@@ -1,4 +1,9 @@
-from tsal.tools.proactive_scanner import scan_todos, scan_typos
+from tsal.tools.proactive_scanner import (
+    scan_todos,
+    scan_typos,
+    scan_todo_file,
+    scan_typos_file,
+)
 
 
 def test_scan_todos(tmp_path):
@@ -8,8 +13,22 @@ def test_scan_todos(tmp_path):
     assert str(f) in res
 
 
+def test_scan_todo_file(tmp_path):
+    f = tmp_path / "x.py"
+    f.write_text("# TODO: note\n")
+    hits = scan_todo_file(f)
+    assert hits and hits[0][0] == 1
+
+
 def test_scan_typos(tmp_path):
     f = tmp_path / "y.py"
     f.write_text("athalaya\n")
     res = scan_typos(str(tmp_path))
     assert str(f) in res
+
+
+def test_scan_typos_file(tmp_path):
+    f = tmp_path / "y.py"
+    f.write_text("athalaya\n")
+    hits = scan_typos_file(f)
+    assert hits and hits[0][0] == 1


### PR DESCRIPTION
## Summary
- add `scan_todo_file` and `scan_typos_file`
- reuse these helpers in watchdog
- expose helpers from `tsal.tools`
- extend unit tests for new functions

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684accef9b00832dbbb19472e41bdb5d