### PR TITLE
Rename executor spiral vector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tri-star_symbolic_assembly_lang"
-version = "0.1.67"
+version = "0.1.68"
 description = "TriStar Assembly Language Core + Brian Spiral Tools"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/unit/test_core/test_tsal_executor.py
+++ b/tests/unit/test_core/test_tsal_executor.py
@@ -1,4 +1,4 @@
-from tsal.core.tsal_executor import TSALExecutor, TSALOp, SpiralVector, ExecutionMode
+from tsal.core.tsal_executor import TSALExecutor, TSALOp, RegisterVector, ExecutionMode
 from tsal.core.executor import MetaFlagProtocol
 
 


### PR DESCRIPTION
## Summary
- differentiate the executor's vector class from the metric SpiralVector
- rename the class to `RegisterVector`
- update imports and tests

## Testing
- `pytest -q` *(fails: 62 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_684acfef8a88832dbfe2fd0c3c7fce86