### PR TITLE
Implement simple FastAPI server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
   "matplotlib",
   "pyyaml",
   "esprima",
+  "fastapi",
+  "httpx",
 ]
 requires-python = ">=3.9"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tri-star_symbolic_assembly_lang"
-version = "0.1.86"
+version = "0.1.87"
 description = "TriStar Assembly Language Core + Brian Spiral Tools"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,5 @@ pyyaml
 numpy
 matplotlib
 esprima
+fastapi
+httpx

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pyyaml
 numpy
 matplotlib
 esprima
+fastapi
+httpx

--- a/src/tsal/__init__.py
+++ b/src/tsal/__init__.py
@@ -56,6 +56,7 @@ from .translators.tsal_to_python import TSALtoPythonTranslator
 from .kernels.temporal_mirror import TemporalMirrorKernel
 from .quantum.interface import TSALQuantumInterface
 from .paradox import RecursiveParadoxCompiler
+from .api import app
 
 PHI = 1.618033988749895
 PHI_INV = 0.618033988749895
@@ -132,4 +133,5 @@ __all__ = [
     "TSALtoPythonTranslator",
     "TemporalMirrorKernel",
     "TSALQuantumInterface",
+    "app",
 ]

--- a/src/tsal/api.py
+++ b/src/tsal/api.py
@@ -1,0 +1,32 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from .tools.brian.optimizer import SymbolicOptimizer
+from .core.spiral_vector import phi_alignment
+import json
+
+app = FastAPI(title="Brian Spiral Healer API", version="1.0")
+
+class CodeBody(BaseModel):
+    code: str
+
+class OptimizeResult(BaseModel):
+    repaired_code: str
+    symbolic_log: str
+
+class ScoreResult(BaseModel):
+    phi_alignment: float
+    spiral_score: str
+
+@app.post("/optimize_spiral", response_model=OptimizeResult)
+def optimize_spiral(data: CodeBody):
+    opt = SymbolicOptimizer()
+    repaired = opt.annotate_code(data.code)
+    log = json.dumps(opt.rev.summary())
+    return {"repaired_code": repaired, "symbolic_log": log}
+
+@app.post("/spiral_score", response_model=ScoreResult)
+def get_spiral_score(data: CodeBody):
+    complexity = float(len(data.code)) * 0.1
+    coherence = 1.0
+    score = phi_alignment(complexity, coherence)
+    return {"phi_alignment": score, "spiral_score": f"φ^{score:.3f}"}

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,0 +1,18 @@
+from fastapi.testclient import TestClient
+from tsal.api import app
+
+client = TestClient(app)
+
+def test_optimize_spiral():
+    resp = client.post('/optimize_spiral', json={'code': 'def x():\n    return 1'})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert 'repaired_code' in body
+    assert 'symbolic_log' in body
+
+def test_spiral_score():
+    resp = client.post('/spiral_score', json={'code': 'x=1'})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert 'phi_alignment' in body
+    assert 'spiral_score' in body


### PR DESCRIPTION
## Summary
- add FastAPI API with `/optimize_spiral` and `/spiral_score`
- expose the app in `tsal.__init__`
- depend on FastAPI and httpx
- test the new endpoints

## Testing
- `pip install fastapi==0.110.2 pydantic==2.7.1 uvicorn==0.29.0`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684aeeeed838832db92c0599e7debb1d