### PR TITLE
Add sanctum export tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ tsal-module-draft = "tsal.tools.module_draft:main"
 tsal-watchdog = "tsal.cli.watchdog:main"
 tsal-state = "tsal.tools.state_tracker:main"
 tsal-party = "tsal.cli.party:main"
+tsal-sanctum-export = "tsal.cli.tsal_sanctum_export:main"
 
 [tool.setuptools.packages.find]
 where = ["src", "tools"]

--- a/src/tsal/cli/tsal_sanctum_export.py
+++ b/src/tsal/cli/tsal_sanctum_export.py
@@ -1,0 +1,4 @@
+from tsal.tools.sanctum_export import main
+
+if __name__ == "__main__":
+    main()

--- a/src/tsal/tools/sanctum_export.py
+++ b/src/tsal/tools/sanctum_export.py
@@ -1,0 +1,71 @@
+"""Export high-integrity constants and oaths."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import hashlib
+from pathlib import Path
+from typing import Dict, Any
+
+import yaml
+
+from tsal.core.oaths import GUARDIAN_OATH, ARC_REACTOR_BOOT_OATH
+from tsal.core.ethics_engine import PRIME_DIRECTIVE
+from tsal.core.guardian_constants import (
+    PHI,
+    PERCEPTION_THRESHOLD,
+    LEARNING_RATE,
+    CONNECTION_DECAY,
+    MAX_NODES,
+    MAX_AGENTS,
+    MAX_DIMENSIONS,
+)
+
+
+def build_sanctum(include_ethics: bool = False) -> Dict[str, Any]:
+    data: Dict[str, Any] = {
+        "constants": {
+            "PHI": PHI,
+            "PERCEPTION_THRESHOLD": PERCEPTION_THRESHOLD,
+            "LEARNING_RATE": LEARNING_RATE,
+            "CONNECTION_DECAY": CONNECTION_DECAY,
+            "MAX_NODES": MAX_NODES,
+            "MAX_AGENTS": MAX_AGENTS,
+            "MAX_DIMENSIONS": MAX_DIMENSIONS,
+        }
+    }
+    if include_ethics:
+        data["prime_directive"] = list(PRIME_DIRECTIVE)
+        data["oath"] = list(GUARDIAN_OATH)
+        data["boot_oath"] = list(ARC_REACTOR_BOOT_OATH)
+    encoded = json.dumps(data, sort_keys=True).encode()
+    data["sha256"] = hashlib.sha256(encoded).hexdigest()
+    return data
+
+
+def export_sanctum(path: str | None, fmt: str = "json", include_ethics: bool = False) -> str:
+    data = build_sanctum(include_ethics=include_ethics)
+    if fmt == "yaml":
+        text = yaml.safe_dump(data, sort_keys=False)
+    else:
+        text = json.dumps(data, indent=2)
+    if path:
+        Path(path).write_text(text)
+    return text
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="export project sanctum")
+    parser.add_argument("--out")
+    parser.add_argument("--format", choices=["json", "yaml"], default="json")
+    parser.add_argument("--include-ethics", action="store_true")
+    args = parser.parse_args()
+
+    result = export_sanctum(args.out, args.format, args.include_ethics)
+    if not args.out:
+        print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_tools/test_sanctum_export.py
+++ b/tests/unit/test_tools/test_sanctum_export.py
@@ -1,0 +1,13 @@
+from tsal.tools.sanctum_export import build_sanctum
+
+
+def test_build_sanctum_hash():
+    data = build_sanctum()
+    assert 'sha256' in data
+    assert 'constants' in data
+
+
+def test_build_sanctum_include_ethics():
+    data = build_sanctum(include_ethics=True)
+    assert 'prime_directive' in data
+    assert 'oath' in data


### PR DESCRIPTION
## Summary
- add CLI tool `tsal-sanctum-export` with JSON/YAML output
- bundle Guardian constants and ethics oath data
- expose script via pyproject
- unit tests for `build_sanctum`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_684b06b41cec832db1785ae5047049c5