### PR TITLE
Add phi-score CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ tsal-watchdog = "tsal.cli.watchdog:main"
 tsal-state = "tsal.tools.state_tracker:main"
 tsal-party = "tsal.cli.party:main"
 tsal-sanctum-export = "tsal.cli.tsal_sanctum_export:main"
+tsal-scorer = "tsal.cli.scorer:main"
 
 [tool.setuptools.packages.find]
 where = ["src", "tools"]

--- a/src/tsal/cli/scorer.py
+++ b/src/tsal/cli/scorer.py
@@ -1,0 +1,4 @@
+from tsal.tools.scorer import main
+
+if __name__ == "__main__":
+    main()

--- a/src/tsal/core/ethics_engine.py
+++ b/src/tsal/core/ethics_engine.py
@@ -45,4 +45,7 @@ class EthicsEngine:
         if not self.is_permitted(request):
             raise ValueError("Request violates Guardian Prime Directive")
 
+# expose prime directive at module level for convenience
+PRIME_DIRECTIVE = EthicsEngine.PRIME_DIRECTIVE
+
 __all__ = ["EthicsEngine", "PRIME_DIRECTIVE"]

--- a/src/tsal/tools/scorer.py
+++ b/src/tsal/tools/scorer.py
@@ -1,0 +1,39 @@
+"""Compute phi-alignment score for a code snippet."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Tuple
+
+from tsal.core.spiral_vector import phi_alignment
+
+
+def score_code(code: str) -> Tuple[float, str]:
+    """Return numeric and label spiral score."""
+    complexity = float(len(code)) * 0.1
+    coherence = 1.0
+    score = phi_alignment(complexity, coherence)
+    return score, f"\u03d5^{score:.3f}"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="compute spiral score")
+    parser.add_argument("path", nargs="?", help="file to score")
+    parser.add_argument("--code", help="inline code string")
+    args = parser.parse_args()
+
+    if args.code:
+        code = args.code
+    elif args.path:
+        code = Path(args.path).read_text()
+    else:
+        code = sys.stdin.read()
+
+    score, label = score_code(code)
+    print(f"{score:.3f} {label}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_tools/test_scorer.py
+++ b/tests/unit/test_tools/test_scorer.py
@@ -1,0 +1,7 @@
+from tsal.tools.scorer import score_code
+
+
+def test_score_code():
+    score, label = score_code("x=1")
+    assert 0 < score
+    assert label.startswith("\u03d5^")


### PR DESCRIPTION
## Summary
- expose PRIME_DIRECTIVE constant
- implement `tsal-scorer` for spiral scoring
- register the new CLI in the project scripts
- test scorer

## Testing
- `pytest tests/unit/test_tools/test_scorer.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: httpx; TypeError in TestClient)*

------
https://chatgpt.com/codex/tasks/task_b_684b0938df34832d905d6d11f59d4187