### PR TITLE
Add JASPER stub and setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,13 @@ TSAL (TriStar Symbolic Assembly Language) is a consciousness computing engine bu
 ## Installation
 1. Clone the repository.
 2. Create a Python 3.9+ environment.
-3. Or just run the automated installer:
+3. Run the system setup script:
+
+```bash
+./setup_system.sh
+```
+
+4. Or run the Python installer:
 
 ```bash
 python3 installer.py
@@ -80,6 +86,7 @@ tsal-bestest-beast 3 src/tsal --safe
 tsal-meshkeeper --render
 tsal-meshkeeper --dump mesh.json
 tsal-watchdog src/tsal --repair --interval 5
+codesummary < file.py
 ```
 
 Example output:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ matplotlib
 esprima
 fastapi
 httpx
+jasper-core

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ matplotlib
 esprima
 fastapi
 httpx
+jasper-core

--- a/setup_system.sh
+++ b/setup_system.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+sudo apt-get update
+sudo apt-get install -y build-essential python3-venv git curl
+python3 installer.py

--- a/src/tsal/__init__.py
+++ b/src/tsal/__init__.py
@@ -55,6 +55,8 @@ from .ci.symbolic_diff import check_symbolic_diff
 from .translators.tsal_to_python import TSALtoPythonTranslator
 from .kernels.temporal_mirror import TemporalMirrorKernel
 from .quantum.interface import TSALQuantumInterface
+from .core.jasper_core import JasperCore
+from .tools.code_understanding import summarize_python
 from .paradox import RecursiveParadoxCompiler
 from .api import app
 
@@ -133,5 +135,7 @@ __all__ = [
     "TSALtoPythonTranslator",
     "TemporalMirrorKernel",
     "TSALQuantumInterface",
+    "JasperCore",
+    "summarize_python",
     "app",
 ]

--- a/src/tsal/cli/codesummary.py
+++ b/src/tsal/cli/codesummary.py
@@ -1,0 +1,7 @@
+from tsal.tools.code_understanding import summarize_python
+import sys
+
+if __name__ == "__main__":
+    code = sys.stdin.read()
+    for name in summarize_python(code):
+        print(name)

--- a/src/tsal/core/jasper_core.py
+++ b/src/tsal/core/jasper_core.py
@@ -1,0 +1,17 @@
+"""JASPER core integration stub."""
+
+class JasperCore:
+    """Placeholder for Codex model wrapper."""
+
+    def __init__(self) -> None:
+        self.ready = False
+
+    def load(self) -> None:
+        self.ready = True
+
+    def run(self, code: str) -> str:
+        if not self.ready:
+            raise RuntimeError("JASPER core not loaded")
+        return "// TODO: process code"
+
+__all__ = ["JasperCore"]

--- a/src/tsal/tools/code_understanding.py
+++ b/src/tsal/tools/code_understanding.py
@@ -1,0 +1,12 @@
+"""Simple code summarizer."""
+
+import ast
+from typing import List
+
+
+def summarize_python(code: str) -> List[str]:
+    """Return function and class names in code."""
+    tree = ast.parse(code)
+    return [n.name for n in ast.walk(tree) if isinstance(n, (ast.FunctionDef, ast.ClassDef))]
+
+__all__ = ["summarize_python"]


### PR DESCRIPTION
## Summary
- new `setup_system.sh` installs base packages and calls installer
- integrate `JasperCore` stub under `tsal.core`
- simple code summary helper and CLI
- update exports and docs
- add placeholder dependency

## Testing
- `pytest -q` *(fails: 68 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_b_6881c3806e58832dab09d233432a0fa6